### PR TITLE
feat: added config filenames to hashFiles

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,9 +55,17 @@ async function restoreMiseCache(): Promise<void> {
   const fileHash = await glob.hashFiles(
     [
       `**/.config/mise/config.toml`,
-      `**/.mise.*.toml`,
-      `**/.mise.toml`,
+      `**/.config/mise/config.*.toml`,
+      `**/.config/mise.toml`,
+      `**/.config/mise.*.toml`,
       `**/.mise/config.toml`,
+      `**/.mise/config.*.toml`,
+      `**/mise/config.toml`,
+      `**/mise/config.*.toml`,
+      `**/.mise.toml`,
+      `**/.mise.*.toml`,
+      `**/mise.toml`,
+      `**/mise.*.toml`,
       `**/.tool-versions`
     ].join('\n')
   )


### PR DESCRIPTION
This PR syncs config filenames to hashFiles for generating cache keys with `DEFAULT_CONFIG_FILENAMES`.
https://github.com/jdx/mise/blob/9a9924e6473036468176014fdac5e8e49ee8123e/src/config/mod.rs#L460-L500

Since I'm unsure about the policy supporting `rtx`, I didn't add them as they are also not listed in the docs.
https://mise.jdx.dev/configuration.html