### PR TITLE
Update README.md to refer to v2 consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: jdx/mise-action@v1
+      - uses: jdx/mise-action@v2
       # .tool-versions will be read from repo root
       - run: node ./my_app.js
 ```


### PR DESCRIPTION
I followed the second part of the docs and copied the wrong version number, leading to https://github.com/jdx/mise-action/issues/95