### PR TITLE
docs: restore estranged comment for tool_versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ jobs:
           install: true # [default: true] run `mise install`
           install_args: "bun" # [default: ""] additional arguments to `mise install`
           cache: true # [default: true] cache mise using GitHub's cache
-          # automatically write this .tool-versions file
           experimental: true # [default: false] enable experimental features
           log_level: debug # [default: info] log level
+          # automatically write this .tool-versions file
           tool_versions: |
             shellcheck 0.9.0
           # or, if you prefer .mise.toml format:


### PR DESCRIPTION
Seems it was meant to be here originally:

https://github.com/jdx/mise-action/commit/5ac46849accbeea2af455874c27379b56c4c89b6#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5