### PR TITLE
fix: MISE_ENV can't be used as key when commas present

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,8 @@ async function restoreMiseCache(): Promise<string | undefined> {
     primaryKey = `${primaryKey}-${version}`
   }
   if (MISE_ENV) {
-    primaryKey = `${primaryKey}-${MISE_ENV}`
+    const sanitizedMiseEnv = MISE_ENV.replace(",", "-")
+    primaryKey = `${primaryKey}-${sanitizedMiseEnv}`
   }
   if (installArgs) {
     const tools = installArgs


### PR DESCRIPTION
Fixes error:
>  Error: Key Validation Error: mise-v0-linux-x64-02a41ed1e2435e2ea2f7cc2c1fab24ed73e1285d8db9acc505bbbd84d99a1b4f-shared,ci cannot contain commas.