### PR TITLE
feat: add environment variable support to cache key templates

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,8 @@ inputs:
     description: |
       Override the complete cache key (ignores all other cache key options).
       Supports template variables: {{version}}, {{cache_key_prefix}}, {{platform}}, {{file_hash}}, 
-      {{mise_env}}, {{install_args_hash}}, {{default}} and conditional logic like {{#if version}}...{{/if}}
+      {{mise_env}}, {{install_args_hash}}, {{default}}, {{env.VAR_NAME}} for environment variables, 
+      and conditional logic like {{#if version}}...{{/if}}
   experimental:
     required: false
     default: "false"

--- a/dist/index.js
+++ b/dist/index.js
@@ -50269,10 +50269,11 @@ async function processCacheKeyTemplate(template) {
     // Calculate the default cache key by processing the default template
     const defaultTemplate = Handlebars.compile(DEFAULT_CACHE_KEY_TEMPLATE);
     const defaultCacheKey = defaultTemplate(baseTemplateData);
-    // Prepare final template data including the default cache key
+    // Prepare final template data including the default cache key and env variables
     const templateData = {
         ...baseTemplateData,
-        default: defaultCacheKey
+        default: defaultCacheKey,
+        env: process.env
     };
     // Compile and execute the user's template
     const compiledTemplate = Handlebars.compile(template);

--- a/src/index.ts
+++ b/src/index.ts
@@ -351,10 +351,11 @@ async function processCacheKeyTemplate(template: string): Promise<string> {
   const defaultTemplate = Handlebars.compile(DEFAULT_CACHE_KEY_TEMPLATE)
   const defaultCacheKey = defaultTemplate(baseTemplateData)
 
-  // Prepare final template data including the default cache key
+  // Prepare final template data including the default cache key and env variables
   const templateData = {
     ...baseTemplateData,
-    default: defaultCacheKey
+    default: defaultCacheKey,
+    env: process.env
   }
 
   // Compile and execute the user's template


### PR DESCRIPTION
## Summary
- Add support for `{{env.VAR_NAME}}` syntax in cache key templates to allow reading environment variable values
- Enables more flexible cache key customization based on CI/CD environment variables like branch names, deployment environments, or custom build identifiers
- Maintains backward compatibility with existing cache key templates

## Examples
```yaml
# Include branch name from environment
cache_key: 'mise-{{env.GITHUB_REF_NAME}}-{{platform}}-{{file_hash}}'

# Use custom deployment environment
cache_key: 'mise-{{env.DEPLOY_ENV}}-{{platform}}-{{file_hash}}'

# Conditional logic with environment variables
cache_key: '{{default}}{{#if env.CUSTOM_SUFFIX}}-{{env.CUSTOM_SUFFIX}}{{/if}}'
```

## Changes
- Modified `processCacheKeyTemplate()` in `src/index.ts` to include `process.env` in template data
- Updated `action.yml` documentation to include the new `{{env.VAR_NAME}}` syntax
- All existing functionality remains unchanged

## Test plan
- [x] Build and package successfully with `npm run all`
- [x] Linting and formatting pass
- [ ] Manual testing with environment variables in cache key templates
- [ ] Verify backward compatibility with existing cache key configurations