### PR TITLE
chore: release v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
 ---
+## [3.3.0](https://github.com/jdx/mise-action/compare/v3.2.0..v3.3.0) - 2025-10-03
+
+### 🚀 Features
+
+- use self-update to modify version if mise is already installed (#277) by [@ImpSy](https://github.com/ImpSy) in [#277](https://github.com/jdx/mise-action/pull/277)
+
+### 🐛 Bug Fixes
+
+- **(cache)** replace `,` in `MISE_ENV` with `-` (#278) by [@risu729](https://github.com/risu729) in [#278](https://github.com/jdx/mise-action/pull/278)
+- correct Renovate allowedPostUpgradeCommands configuration by [@jdx](https://github.com/jdx) in [4313941](https://github.com/jdx/mise-action/commit/43139419dcaeb99e24c487d646766d014d0957a2)
+
+### ⚙️ Miscellaneous Tasks
+
+- **(config)** migrate renovate config (#263) by [@renovate[bot]](https://github.com/renovate[bot]) in [#263](https://github.com/jdx/mise-action/pull/263)
+- updated deps by [@jdx](https://github.com/jdx) in [5795893](https://github.com/jdx/mise-action/commit/5795893acedc0f2044498a21005c38f12dd5d8d3)
+
+### New Contributors
+
+* @ImpSy made their first contribution in [#277](https://github.com/jdx/mise-action/pull/277)
+
+---
 ## [3.2.0](https://github.com/jdx/mise-action/compare/v3.1.0..v3.2.0) - 2025-08-22
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mise-action",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mise-action",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "jdx",
   "private": true,
   "repository": {


### PR DESCRIPTION

---
## [3.3.0](https://github.com/jdx/mise-action/compare/v3.2.0..v3.3.0) - 2025-10-03

### 🚀 Features

- use self-update to modify version if mise is already installed (#277) by [@ImpSy](https://github.com/ImpSy) in [#277](https://github.com/jdx/mise-action/pull/277)

### 🐛 Bug Fixes

- **(cache)** replace `,` in `MISE_ENV` with `-` (#278) by [@risu729](https://github.com/risu729) in [#278](https://github.com/jdx/mise-action/pull/278)
- correct Renovate allowedPostUpgradeCommands configuration by [@jdx](https://github.com/jdx) in [4313941](https://github.com/jdx/mise-action/commit/43139419dcaeb99e24c487d646766d014d0957a2)

### ⚙️ Miscellaneous Tasks

- **(config)** migrate renovate config (#263) by [@renovate[bot]](https://github.com/renovate[bot]) in [#263](https://github.com/jdx/mise-action/pull/263)
- updated deps by [@jdx](https://github.com/jdx) in [5795893](https://github.com/jdx/mise-action/commit/5795893acedc0f2044498a21005c38f12dd5d8d3)

### New Contributors

* @ImpSy made their first contribution in [#277](https://github.com/jdx/mise-action/pull/277)

<!-- generated by git-cliff -->