### PR TITLE
docs: update to v3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v3
         with:
           version: 2024.10.0 # [default: latest] mise version to install
           install: true # [default: true] run `mise install`
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v3
       # .tool-versions will be read from repo root
       - run: node ./my_app.js
 ```
@@ -47,7 +47,7 @@ jobs:
 You can customize the cache key used by the action:
 
 ```yaml
-- uses: jdx/mise-action@v2
+- uses: jdx/mise-action@v3
   with:
     cache_key: "my-custom-cache-key"  # Override the entire cache key
     cache_key_prefix: "mise-v1"       # Or just change the prefix (default: "mise-v0")
@@ -58,7 +58,7 @@ You can customize the cache key used by the action:
 When using `cache_key`, you can use template variables to reference internal values:
 
 ```yaml
-- uses: jdx/mise-action@v2
+- uses: jdx/mise-action@v3
   with:
     cache_key: "mise-{{platform}}-{{version}}-{{file_hash}}"
     version: "2024.10.0"
@@ -78,7 +78,7 @@ Conditional logic is also supported using Handlebars syntax like `{{#if version}
 
 Example using multiple variables:
 ```yaml
-- uses: jdx/mise-action@v2
+- uses: jdx/mise-action@v3
   with:
     cache_key: "mise-v1-{{platform}}-{{install_args_hash}}-{{file_hash}}"
     install_args: "node@20 python@3.12"
@@ -86,7 +86,7 @@ Example using multiple variables:
 
 You can also extend the default cache key:
 ```yaml
-- uses: jdx/mise-action@v2
+- uses: jdx/mise-action@v3
   with:
     cache_key: "{{default}}-custom-suffix"
     install_args: "node@20 python@3.12"
@@ -99,7 +99,7 @@ This gives you full control over cache invalidation based on the specific aspect
 When installing tools hosted on GitHub (like `gh`, `node`, `bun`, etc.), mise needs to make API calls to GitHub's releases API. Without authentication, these calls are subject to GitHub's rate limit of 60 requests per hour, which can cause installation failures.
 
 ```yaml
-- uses: jdx/mise-action@v2
+- uses: jdx/mise-action@v3
   with:
     github_token: ${{ secrets.GITHUB_TOKEN }}
     # your other configuration


### PR DESCRIPTION
This PR updates the README to replace jdx/mise-action@v2 by jdx/mise-action@v3 in examples.