### PR TITLE
fix: auto-update dist folder in Renovate PRs via GitHub Actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,23 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>jdx/renovate-config"],
-  "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "postUpgradeTasks": {
-        "commands": [],
-        "fileFilters": [],
-        "executionMode": "branch"
-      }
-    },
-    {
-      "matchManagers": ["npm"],
-      "postUpgradeTasks": {
-        "commands": ["npm run all"],
-        "fileFilters": ["dist/**/*"],
-        "executionMode": "branch"
-      }
-    }
-  ],
-  "allowedCommands": ["^npm run all$"]
+  "extends": ["github>jdx/renovate-config"]
 }

--- a/.github/workflows/renovate-dist-update.yml
+++ b/.github/workflows/renovate-dist-update.yml
@@ -1,0 +1,52 @@
+name: Update Distribution on Renovate PRs
+
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/**'
+      - 'tsconfig.json'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-dist:
+    # Only run for Renovate PRs
+    if: github.actor == 'renovate[bot]' || github.actor == 'renovate-bot'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and package
+        run: npm run all
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code dist/ || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add dist/
+          git commit -m "chore: rebuild distribution"
+          git push


### PR DESCRIPTION
## Summary

Fixes the artifact update problem in Renovate PRs (like #294) by replacing non-functional `postUpgradeTasks` configuration with a GitHub Actions workflow.

## Problem

The previous configuration used `postUpgradeTasks` and `allowedCommands` in `.github/renovate.json`, which only work with self-hosted Renovate. Since this repo uses GitHub's hosted Renovate app, those settings were being ignored, causing the `dist/` folder to not be updated automatically.

## Solution

Created a new GitHub Actions workflow (`.github/workflows/renovate-dist-update.yml`) that:
- Automatically triggers when Renovate opens a PR that modifies `package.json`, `package-lock.json`, or `src/`
- Only runs for Renovate bot PRs
- Runs `npm run all` to rebuild the distribution
- Commits and pushes the updated `dist/` folder back to the PR branch

Also cleaned up `.github/renovate.json` by removing the non-functional configuration.

## Testing

The workflow will automatically run on the next Renovate PR update. You can test it immediately by:
1. Closing and reopening PR #294, or
2. Waiting for the next Renovate update cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace Renovate post-upgrade tasks with a GitHub Actions workflow that rebuilds and commits `dist/` on Renovate PRs.
> 
> - **CI / GitHub Actions**:
>   - Add `/.github/workflows/renovate-dist-update.yml` to auto-rebuild `dist/` on Renovate PRs.
>     - Triggers on changes to `package.json`, `package-lock.json`, `src/**`, `tsconfig.json`.
>     - Runs only for `renovate[bot]`/`renovate-bot`; executes `npm ci` and `npm run all`; commits updated `dist/` if changed.
> - **Renovate Config**:
>   - Simplify `/.github/renovate.json` by removing `postUpgradeTasks` and `allowedCommands`, keeping only `extends`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 631581469eea37c64b833bd5d7119d1860fec0f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->