### PR TITLE
feat: use autofix.ci to auto-update dist/ on all PRs

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,18 +1,21 @@
-name: Auto-update Distribution
+name: autofix.ci
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
 
 jobs:
-  update-dist:
+  autofix:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -27,4 +30,4 @@ jobs:
         run: npm run all
 
       - name: autofix.ci
-        uses: autofix-ci/action@ff86a557419858bb967097bfc916833f5647fa8c
+        uses: autofix-ci/action@v1


### PR DESCRIPTION
## Summary

Switches from our custom GitHub Actions workflow to [autofix.ci](https://autofix.ci/) for automatically updating the `dist/` folder. This solves the CI triggering issue and works on all PRs, not just Renovate PRs.

## Problem Solved

The previous workflow had a critical issue: commits made with `GITHUB_TOKEN` don't trigger other CI workflows (by design to prevent infinite loops). This meant that after the dist/ folder was updated, CI wouldn't run to verify the changes.

## Solution: autofix.ci

autofix.ci uses a GitHub App token to make commits, which **does** trigger CI workflows. This ensures that:
- ✅ CI tests run after dist/ is updated
- ✅ Works on ALL PRs, not just Renovate
- ✅ Renovate still recognizes and can rebase PRs (via `gitIgnoredAuthors`)

## Changes

- **Renamed workflow**: `renovate-dist-update.yml` → `autofix.yml`
- **Removed filters**: Now runs on all PRs (not just when specific files change)
- **Removed Renovate check**: Works for all PR authors, not just renovate[bot]
- **Switched to autofix.ci**: Replaced manual commit logic with autofix.ci action
- **Updated permissions**: Changed from `write` to `read` (autofix.ci handles commits)
- **Updated renovate.json**: Added `autofix.ci[bot]` to `gitIgnoredAuthors`

## Setup Required

This PR requires installing the autofix.ci GitHub App:
👉 https://github.com/apps/autofix-ci

## Testing

Once the app is installed, this workflow will automatically:
1. Run on every PR
2. Execute `npm run all` to rebuild dist/
3. Let autofix.ci commit any changes
4. Trigger CI workflows to verify the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a GitHub Actions workflow that builds with Node 24 on PRs and main pushes, then uses autofix.ci to commit resulting changes.
> 
> - **CI**:
>   - **New Workflow** `/.github/workflows/autofix.yml`:
>     - Triggers on `pull_request` and pushes to `main`.
>     - Sets `contents: read` permissions.
>     - Checks out code, sets up Node.js `24` with npm cache, runs `npm ci` and `npm run all`.
>     - Invokes `autofix-ci/action@v1` to commit resulting changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d165eadb83db077ee076d4be4b52da91d61d74d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->