### PR TITLE
chore: release v3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 ---
+## [3.4.1](https://github.com/jdx/mise-action/compare/v3.4.0..v3.4.1) - 2025-11-13
+
+### 🐛 Bug Fixes
+
+- avoid github token downstream issue (#317) by [@acesyde](https://github.com/acesyde) in [#317](https://github.com/jdx/mise-action/pull/317)
+
+### New Contributors
+
+* @acesyde made their first contribution in [#317](https://github.com/jdx/mise-action/pull/317)
+
+---
 ## [3.4.0](https://github.com/jdx/mise-action/compare/v3.3.1..v3.4.0) - 2025-10-31
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mise-action",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mise-action",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "author": "jdx",
   "private": true,
   "repository": {


### PR DESCRIPTION

---
## [3.4.1](https://github.com/jdx/mise-action/compare/v3.4.0..v3.4.1) - 2025-11-13

### 🐛 Bug Fixes

- avoid github token downstream issue (#317) by [@acesyde](https://github.com/acesyde) in [#317](https://github.com/jdx/mise-action/pull/317)

### New Contributors

* @acesyde made their first contribution in [#317](https://github.com/jdx/mise-action/pull/317)

<!-- generated by git-cliff -->