### PR TITLE
chore: release v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 ---
+## [3.5.0](https://github.com/jdx/mise-action/compare/v3.4.1..v3.5.0) - 2025-11-21
+
+### 🚀 Features
+
+- **(action)** moved save cache to post step (#321) by [@aamkye](https://github.com/aamkye) in [#321](https://github.com/jdx/mise-action/pull/321)
+
+### New Contributors
+
+* @aamkye made their first contribution in [#321](https://github.com/jdx/mise-action/pull/321)
+
+---
 ## [3.4.1](https://github.com/jdx/mise-action/compare/v3.4.0..v3.4.1) - 2025-11-13
 
 ### 🐛 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mise-action",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mise-action",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "author": "jdx",
   "private": true,
   "repository": {


### PR DESCRIPTION

---
## [3.5.0](https://github.com/jdx/mise-action/compare/v3.4.1..v3.5.0) - 2025-11-21

### 🚀 Features

- **(action)** moved save cache to post step (#321) by [@aamkye](https://github.com/aamkye) in [#321](https://github.com/jdx/mise-action/pull/321)

### New Contributors

* @aamkye made their first contribution in [#321](https://github.com/jdx/mise-action/pull/321)

<!-- generated by git-cliff -->