### PR TITLE
chore: release v3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ---
+## [3.5.1](https://github.com/jdx/mise-action/compare/v3.5.0..v3.5.1) - 2025-11-24
+
+### 🔍 Other Changes
+
+- Revert "feat(action): moved save cache to post step" (#329) by [@jdx](https://github.com/jdx) in [#329](https://github.com/jdx/mise-action/pull/329)
+
+---
 ## [3.5.0](https://github.com/jdx/mise-action/compare/v3.4.1..v3.5.0) - 2025-11-21
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mise-action",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mise-action",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "author": "jdx",
   "private": true,
   "repository": {


### PR DESCRIPTION

---
## [3.5.1](https://github.com/jdx/mise-action/compare/v3.5.0..v3.5.1) - 2025-11-24

### 🔍 Other Changes

- Revert "feat(action): moved save cache to post step" (#329) by [@jdx](https://github.com/jdx) in [#329](https://github.com/jdx/mise-action/pull/329)

<!-- generated by git-cliff -->