### PR TITLE
chore: release v3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ---
+## [3.6.1](https://github.com/jdx/mise-action/compare/v3.6.0..v3.6.1) - 2026-01-20
+
+### 🔍 Other Changes
+
+- Revert "fix(cache): isolate cache keys per working_directory in monorepos" (#364) by [@jdx](https://github.com/jdx) in [#364](https://github.com/jdx/mise-action/pull/364)
+
+---
 ## [3.6.0](https://github.com/jdx/mise-action/compare/v3.5.1..v3.6.0) - 2026-01-18
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mise-action",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mise-action",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "author": "jdx",
   "private": true,
   "repository": {


### PR DESCRIPTION

---
## [3.6.1](https://github.com/jdx/mise-action/compare/v3.6.0..v3.6.1) - 2026-01-20

### 🔍 Other Changes

- Revert "fix(cache): isolate cache keys per working_directory in monorepos" (#364) by [@jdx](https://github.com/jdx) in [#364](https://github.com/jdx/mise-action/pull/364)

<!-- generated by git-cliff -->