### PR TITLE
chore: release v3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 ---
+## [3.6.2](https://github.com/jdx/mise-action/compare/v3.6.1..v3.6.2) - 2026-03-02
+
+### 🐛 Bug Fixes
+
+- move file_hash to end of cache key template to prevent prefix matching (#384) by [@altendky](https://github.com/altendky) in [#384](https://github.com/jdx/mise-action/pull/384)
+
+### New Contributors
+
+* @altendky made their first contribution in [#384](https://github.com/jdx/mise-action/pull/384)
+
+---
 ## [3.6.1](https://github.com/jdx/mise-action/compare/v3.6.0..v3.6.1) - 2026-01-20
 
 ### 🔍 Other Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mise-action",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mise-action",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "author": "jdx",
   "private": true,
   "repository": {


### PR DESCRIPTION

---
## [3.6.2](https://github.com/jdx/mise-action/compare/v3.6.1..v3.6.2) - 2026-03-02

### 🐛 Bug Fixes

- move file_hash to end of cache key template to prevent prefix matching (#384) by [@altendky](https://github.com/altendky) in [#384](https://github.com/jdx/mise-action/pull/384)

### New Contributors

* @altendky made their first contribution in [#384](https://github.com/jdx/mise-action/pull/384)

<!-- generated by git-cliff -->