### PR TITLE
chore: release v3.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 ---
+## [3.6.3](https://github.com/jdx/mise-action/compare/v3.6.2..v3.6.3) - 2026-03-06
+
+### 🐛 Bug Fixes
+
+- pass cwd to all exec calls in exportMiseEnv() (#390) by [@andrewthauer](https://github.com/andrewthauer) in [#390](https://github.com/jdx/mise-action/pull/390)
+
+### New Contributors
+
+* @andrewthauer made their first contribution in [#390](https://github.com/jdx/mise-action/pull/390)
+
+---
 ## [3.6.2](https://github.com/jdx/mise-action/compare/v3.6.1..v3.6.2) - 2026-03-02
 
 ### 🐛 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mise-action",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mise-action",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "author": "jdx",
   "private": true,
   "repository": {


### PR DESCRIPTION

---
## [3.6.3](https://github.com/jdx/mise-action/compare/v3.6.2..v3.6.3) - 2026-03-06

### 🐛 Bug Fixes

- pass cwd to all exec calls in exportMiseEnv() (#390) by [@andrewthauer](https://github.com/andrewthauer) in [#390](https://github.com/jdx/mise-action/pull/390)

### New Contributors

* @andrewthauer made their first contribution in [#390](https://github.com/jdx/mise-action/pull/390)

<!-- generated by git-cliff -->