### PR TITLE
chore: release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 
 ---
+## [4.1.0](https://github.com/jdx/mise-action/compare/v4.0.1..v4.1.0) - 2026-05-15
+
+### 🚀 Features
+
+- add wings_enabled input (mise-wings cache integration) (#454) by [@jdx](https://github.com/jdx) in [#454](https://github.com/jdx/mise-action/pull/454)
+
+### 🐛 Bug Fixes
+
+- **(ci)** add gh auth setup-git to release-plz.sh (#473) by [@jdx](https://github.com/jdx) in [#473](https://github.com/jdx/mise-action/pull/473)
+- include runner image in cache key to prevent cross-provider collisions (#456) by [@jdx](https://github.com/jdx) in [#456](https://github.com/jdx/mise-action/pull/456)
+- install mise-shim.exe on Windows (#476) by [@risu729](https://github.com/risu729) in [#476](https://github.com/jdx/mise-action/pull/476)
+
+### ⚙️ Miscellaneous Tasks
+
+- **(ci)** use !cancelled() instead of always() for final job (#460) by [@jdx](https://github.com/jdx) in [#460](https://github.com/jdx/mise-action/pull/460)
+- **(ci)** remove autofix.ci workflow (#470) by [@jdx](https://github.com/jdx) in [#470](https://github.com/jdx/mise-action/pull/470)
+- **(ci)** add zizmor workflow for github actions security analysis (#471) by [@jdx](https://github.com/jdx) in [#471](https://github.com/jdx/mise-action/pull/471)
+- add communique to enhance release notes (#411) by [@jdx](https://github.com/jdx) in [#411](https://github.com/jdx/mise-action/pull/411)
+- migrate from ncc (CJS) to rollup (ESM) (#436) by [@jdx](https://github.com/jdx) in [#436](https://github.com/jdx/mise-action/pull/436)
+- add final job to aggregate build-test results (#438) by [@jdx](https://github.com/jdx) in [#438](https://github.com/jdx/mise-action/pull/438)
+- migrate package manager from npm/pnpm/bun to aube (#455) by [@jdx](https://github.com/jdx) in [#455](https://github.com/jdx/mise-action/pull/455)
+- remove pull_request_target workflow (#469) by [@jdx](https://github.com/jdx) in [#469](https://github.com/jdx/mise-action/pull/469)
+
+---
 ## [4.0.1](https://github.com/jdx/mise-action/compare/v4.0.0..v4.0.1) - 2026-03-22
 
 ### 🐛 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mise-action",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mise-action",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "author": "jdx",
   "type": "module",
   "private": true,


### PR DESCRIPTION

---
## [4.1.0](https://github.com/jdx/mise-action/compare/v4.0.1..v4.1.0) - 2026-05-15

### 🚀 Features

- add wings_enabled input (mise-wings cache integration) (#454) by [@jdx](https://github.com/jdx) in [#454](https://github.com/jdx/mise-action/pull/454)

### 🐛 Bug Fixes

- **(ci)** add gh auth setup-git to release-plz.sh (#473) by [@jdx](https://github.com/jdx) in [#473](https://github.com/jdx/mise-action/pull/473)
- include runner image in cache key to prevent cross-provider collisions (#456) by [@jdx](https://github.com/jdx) in [#456](https://github.com/jdx/mise-action/pull/456)
- install mise-shim.exe on Windows (#476) by [@risu729](https://github.com/risu729) in [#476](https://github.com/jdx/mise-action/pull/476)

### ⚙️ Miscellaneous Tasks

- **(ci)** use !cancelled() instead of always() for final job (#460) by [@jdx](https://github.com/jdx) in [#460](https://github.com/jdx/mise-action/pull/460)
- **(ci)** remove autofix.ci workflow (#470) by [@jdx](https://github.com/jdx) in [#470](https://github.com/jdx/mise-action/pull/470)
- **(ci)** add zizmor workflow for github actions security analysis (#471) by [@jdx](https://github.com/jdx) in [#471](https://github.com/jdx/mise-action/pull/471)
- add communique to enhance release notes (#411) by [@jdx](https://github.com/jdx) in [#411](https://github.com/jdx/mise-action/pull/411)
- migrate from ncc (CJS) to rollup (ESM) (#436) by [@jdx](https://github.com/jdx) in [#436](https://github.com/jdx/mise-action/pull/436)
- add final job to aggregate build-test results (#438) by [@jdx](https://github.com/jdx) in [#438](https://github.com/jdx/mise-action/pull/438)
- migrate package manager from npm/pnpm/bun to aube (#455) by [@jdx](https://github.com/jdx) in [#455](https://github.com/jdx/mise-action/pull/455)
- remove pull_request_target workflow (#469) by [@jdx](https://github.com/jdx) in [#469](https://github.com/jdx/mise-action/pull/469)

<!-- generated by git-cliff -->