### PR TITLE
ci: add final job to aggregate build-test results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,3 +146,19 @@ jobs:
       - run: mise x jq -- jq --version
       - run: which jq
       - run: jq --version
+
+  final:
+    needs:
+      - build
+      - test
+      - specific_version
+      - checksum_failure
+      - custom_cache_key
+      - fetch_from_github
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    if: always()
+    steps:
+      - name: Check CI job results
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: exit 1


### PR DESCRIPTION
## Summary
- Add a `final` job to the build-test workflow that depends on all other jobs
- Fails if any upstream job failed or was skipped
- Provides a single required status check for branch protection

## Test plan
- [ ] `final` job passes when all other jobs pass
- [ ] `final` job fails when any upstream job fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; primary risk is CI/branch protection behavior changing (the new `final` job can fail when upstream jobs are skipped/cancelled).
> 
> **Overview**
> Adds a `final` GitHub Actions job to the `build-test` workflow that **always runs** after all other jobs and exits non-zero if any dependency job was `failure`, `cancelled`, or `skipped`.
> 
> This provides a single aggregated status check suitable for branch protection, instead of requiring each individual job to be marked as required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5ac8b3d387f134048d9049011087f6ecfdd049c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->