### PR TITLE
chore(ci): use !cancelled() instead of always() for final job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,9 @@ jobs:
       - fetch_from_github
     runs-on: ubuntu-latest
     timeout-minutes: 1
-    if: always()
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
     steps:
       - name: Check CI job results
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')


### PR DESCRIPTION
## Summary
- Combined with the workflow's `cancel-in-progress` group, `if: always()` overrides cancellation and runs the `final` aggregator even on superseded commits.
- `!cancelled()` still runs on upstream success or failure but skips when the workflow is cancelled — saves a runner and avoids confusing error annotations on already-superseded shas.
- Caught by Cursor Bugbot on a sibling repo (endevco/pitchfork#413). Same `final`-aggregator pattern + `cancel-in-progress: true` here, so the same fix applies.

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just adjusts when the `final` job runs; main risk is slightly different status reporting when runs are cancelled.
> 
> **Overview**
> Updates the GitHub Actions `final` aggregator job to use `if: ${{ !cancelled() }}` instead of `always()`, so it still runs for upstream success/failure but **does not** run for cancelled workflows (e.g., superseded runs under `cancel-in-progress`).
> 
> Adds clarifying comments to document why cancellation should skip the aggregator to avoid wasting runners and producing noise on cancelled commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c62d5f2f15a7ec348da1cd8a3cf3fc52a30f2cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->