### PR TITLE
feat: opt in to caching mise rust toolchains

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,24 @@ jobs:
       - run: which jq
       - run: jq --version
 
+  rust_cache_setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup mise with Rust cache paths
+        uses: ./
+        with:
+          install: false
+          cache_save: false
+          cache_key: "rust-cache-setup-${{ github.run_id }}"
+          cache_rust: true
+      - name: Check Rust cache paths
+        run: |
+          test "$MISE_RUSTUP_HOME" = "$HOME/.local/share/mise/rustup"
+          test "$MISE_CARGO_HOME" = "$HOME/.local/share/mise/cargo"
+          test -d "$MISE_RUSTUP_HOME"
+          test -d "$MISE_CARGO_HOME"
+
   fetch_from_github:
     runs-on: ubuntu-latest
     steps:
@@ -153,6 +171,7 @@ jobs:
       - specific_version
       - checksum_failure
       - custom_cache_key
+      - rust_cache_setup
       - fetch_from_github
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,8 +141,16 @@ jobs:
           cache_rust: true
       - name: Check Rust cache paths
         run: |
-          test "$MISE_RUSTUP_HOME" = "$HOME/.local/share/mise/rustup"
-          test "$MISE_CARGO_HOME" = "$HOME/.local/share/mise/cargo"
+          if [ -n "${MISE_DATA_DIR:-}" ]; then
+            mise_data_dir="$MISE_DATA_DIR"
+          elif [ -n "${XDG_DATA_HOME:-}" ]; then
+            mise_data_dir="$XDG_DATA_HOME/mise"
+          else
+            mise_data_dir="$HOME/.local/share/mise"
+          fi
+
+          test "$MISE_RUSTUP_HOME" = "$mise_data_dir/rustup"
+          test "$MISE_CARGO_HOME" = "$mise_data_dir/cargo"
           test -d "$MISE_RUSTUP_HOME"
           test -d "$MISE_CARGO_HOME"
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ jobs:
           install: true # [default: true] run `mise install`
           install_args: "bun" # [default: ""] additional arguments to `mise install`
           cache: true # [default: true] cache mise using GitHub's cache
+          cache_rust: false # [default: false] also cache Rust toolchains installed by mise
           experimental: true # [default: false] enable experimental features
           log_level: debug # [default: info] log level
           # automatically write this .tool-versions file
@@ -72,6 +73,7 @@ Available template variables:
 - `{{file_hash}}` - Hash of all mise configuration files
 - `{{mise_env}}` - The MISE_ENV environment variable value
 - `{{install_args_hash}}` - SHA256 hash of the sorted tools from install args
+- `{{cache_rust}}` - Whether the Rust toolchain cache integration is enabled
 - `{{default}}` - The processed default cache key (useful for extending)
 
 Conditional logic is also supported using Handlebars syntax like `{{#if version}}...{{/if}}`.
@@ -93,6 +95,22 @@ You can also extend the default cache key:
 ```
 
 This gives you full control over cache invalidation based on the specific aspects that matter to your workflow.
+
+### Rust Toolchain Cache
+
+By default, mise-action only caches mise's data directory. Rust is different from most mise tools because mise delegates Rust installation to rustup, which stores toolchains in `RUSTUP_HOME` and cargo/rustup proxy binaries in `CARGO_HOME/bin`. That state may live outside the mise data directory, so a restored mise cache can otherwise make `mise install` think Rust is present while components such as `rustfmt` or `clippy` are missing.
+
+If mise is responsible for installing Rust in your workflow, opt in to Rust toolchain caching:
+
+```yaml
+- uses: jdx/mise-action@v4
+  with:
+    cache_rust: true
+```
+
+When enabled, the action exports `MISE_RUSTUP_HOME` and `MISE_CARGO_HOME` to directories under the mise data dir before cache restore and install. Those directories are then restored and saved with the normal mise cache. The default cache key includes a `-rust` segment when this option is enabled so Rust-enabled caches do not reuse older mise-only caches. If you override `cache_key`, include `{{cache_rust}}` or otherwise invalidate that key when enabling this option.
+
+Leave `cache_rust` as `false` when Rust is installed or cached by another action such as `rustup`, `actions-rust-lang/setup-rust-toolchain`, or `Swatinem/rust-cache`, and you use mise for other tools. `Swatinem/rust-cache` remains useful alongside this option for Cargo registry, git dependency, and `target` build artifact caching.
 
 ## GitHub API Rate Limits
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,23 @@ If mise is responsible for installing Rust in your workflow, opt in to Rust tool
 
 When enabled, the action exports `MISE_RUSTUP_HOME` and `MISE_CARGO_HOME` to directories under the mise data dir before cache restore and install. Those directories are then restored and saved with the normal mise cache. With the default `env: true`, mise may also export `RUSTUP_HOME` and `CARGO_HOME` for later workflow steps so plain `cargo`, `rustfmt`, and `clippy` commands use the same cached homes. The default cache key includes a `-rust` segment when this option is enabled so Rust-enabled caches do not reuse older mise-only caches. If you override `cache_key`, include `{{cache_rust}}` or otherwise invalidate that key when enabling this option.
 
-Leave `cache_rust` as `false` when Rust is installed or cached by another action such as `rustup`, `actions-rust-lang/setup-rust-toolchain`, or `Swatinem/rust-cache`, and you use mise for other tools. `Swatinem/rust-cache` remains useful alongside this option for Cargo registry, git dependency, and `target` build artifact caching.
+This cache is intended for the Rust toolchain state that mise needs to restore: rustup toolchains and metadata in `RUSTUP_HOME`, plus cargo/rustup proxy binaries and Cargo-installed tool metadata in `CARGO_HOME`. `CARGO_HOME` can also contain registry and git dependency caches, but the mise-action cache key is based on mise configuration, not `Cargo.lock`, and mise-action saves before later workflow build steps run. Do not use `cache_rust` as a replacement for a Cargo dependency or `target` cache.
+
+Use `cache_rust` with `Swatinem/rust-cache` when mise installs Rust and you want rust-cache to manage Cargo registry, git dependency, and `target` build artifact caching:
+
+```yaml
+- uses: jdx/mise-action@v4
+  with:
+    cache_rust: true
+
+- uses: Swatinem/rust-cache@v2
+  with:
+    # Let mise-action own rustup/cargo proxy binaries and Cargo tools installed by mise.
+    # Remove this line if you want rust-cache to cache Cargo binaries installed later in the job.
+    cache-bin: "false"
+```
+
+Put `Swatinem/rust-cache` after mise-action so it sees the Rust version and `CARGO_HOME` exported by mise. Leave `cache_rust` as `false` when Rust is installed by another action such as `rustup` or `actions-rust-lang/setup-rust-toolchain`, and you use mise only for non-Rust tools.
 
 ## GitHub API Rate Limits
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If mise is responsible for installing Rust in your workflow, opt in to Rust tool
     cache_rust: true
 ```
 
-When enabled, the action exports `MISE_RUSTUP_HOME` and `MISE_CARGO_HOME` to directories under the mise data dir before cache restore and install. Those directories are then restored and saved with the normal mise cache. The default cache key includes a `-rust` segment when this option is enabled so Rust-enabled caches do not reuse older mise-only caches. If you override `cache_key`, include `{{cache_rust}}` or otherwise invalidate that key when enabling this option.
+When enabled, the action exports `MISE_RUSTUP_HOME` and `MISE_CARGO_HOME` to directories under the mise data dir before cache restore and install. Those directories are then restored and saved with the normal mise cache. With the default `env: true`, mise may also export `RUSTUP_HOME` and `CARGO_HOME` for later workflow steps so plain `cargo`, `rustfmt`, and `clippy` commands use the same cached homes. The default cache key includes a `-rust` segment when this option is enabled so Rust-enabled caches do not reuse older mise-only caches. If you override `cache_key`, include `{{cache_rust}}` or otherwise invalidate that key when enabling this option.
 
 Leave `cache_rust` as `false` when Rust is installed or cached by another action such as `rustup`, `actions-rust-lang/setup-rust-toolchain`, or `Swatinem/rust-cache`, and you use mise for other tools. `Swatinem/rust-cache` remains useful alongside this option for Cargo registry, git dependency, and `target` build artifact caching.
 

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,10 @@ inputs:
       rustup metadata, and cargo/rustup proxy binaries that mise needs for
       Rust components such as rustfmt and clippy.
 
+      With the default `env: true`, mise may also export `RUSTUP_HOME` and
+      `CARGO_HOME` for later workflow steps so plain `cargo`, `rustfmt`, and
+      `clippy` commands use the same cached homes.
+
       Default `false` keeps existing workflows unchanged, especially jobs that
       install Rust with rustup, rust-cache, setup-rust-toolchain, or another
       standard Rust action and use mise only for other tools.

--- a/action.yml
+++ b/action.yml
@@ -50,8 +50,23 @@ inputs:
     description: |
       Override the complete cache key (ignores all other cache key options).
       Supports template variables: {{version}}, {{cache_key_prefix}}, {{platform}}, {{file_hash}}, 
-      {{mise_env}}, {{install_args_hash}}, {{default}}, {{env.VAR_NAME}} for environment variables, 
+      {{mise_env}}, {{install_args_hash}}, {{cache_rust}}, {{default}}, {{env.VAR_NAME}} for environment variables,
       and conditional logic like {{#if version}}...{{/if}}
+  cache_rust:
+    required: false
+    default: "false"
+    description: |
+      Opt in to caching Rust toolchains installed by mise's Rust backend.
+
+      When `true`, the action exports `MISE_RUSTUP_HOME` and `MISE_CARGO_HOME`
+      to directories under the mise data dir before restoring the mise cache.
+      This lets the existing mise cache save/restore rustup toolchains,
+      rustup metadata, and cargo/rustup proxy binaries that mise needs for
+      Rust components such as rustfmt and clippy.
+
+      Default `false` keeps existing workflows unchanged, especially jobs that
+      install Rust with rustup, rust-cache, setup-rust-toolchain, or another
+      standard Rust action and use mise only for other tools.
   experimental:
     required: false
     default: "false"

--- a/action.yml
+++ b/action.yml
@@ -68,9 +68,13 @@ inputs:
       `CARGO_HOME` for later workflow steps so plain `cargo`, `rustfmt`, and
       `clippy` commands use the same cached homes.
 
+      This is a Rust toolchain/proxy cache, not a Cargo dependency or build
+      cache. Use it with Swatinem/rust-cache when mise installs Rust and
+      rust-cache should own Cargo registry, git dependency, and target caches.
+
       Default `false` keeps existing workflows unchanged, especially jobs that
-      install Rust with rustup, rust-cache, setup-rust-toolchain, or another
-      standard Rust action and use mise only for other tools.
+      install Rust with rustup, setup-rust-toolchain, or another standard Rust
+      action and use mise only for other tools.
   experimental:
     required: false
     default: "false"

--- a/dist/index.js
+++ b/dist/index.js
@@ -89033,17 +89033,22 @@ async function setupRustCache() {
         warning('cache_rust is enabled, but cache is false. Rust cache setup is skipped.');
         return;
     }
+    if (!getBooleanInput('cache_save')) {
+        warning('cache_rust is enabled, but cache_save is false. Rust cache paths will be restored for this run but not saved.');
+    }
     const { rustupHome, cargoHome } = rustCacheHomes();
     if (process.env.MISE_RUSTUP_HOME) {
-        info(`mise rust cache: using MISE_RUSTUP_HOME=${rustupHome}`);
+        info(`mise rust cache: using pre-set MISE_RUSTUP_HOME=${rustupHome}`);
     }
     else {
+        info(`mise rust cache: exporting MISE_RUSTUP_HOME=${rustupHome}`);
         exportVariable('MISE_RUSTUP_HOME', rustupHome);
     }
     if (process.env.MISE_CARGO_HOME) {
-        info(`mise rust cache: using MISE_CARGO_HOME=${cargoHome}`);
+        info(`mise rust cache: using pre-set MISE_CARGO_HOME=${cargoHome}`);
     }
     else {
+        info(`mise rust cache: exporting MISE_CARGO_HOME=${cargoHome}`);
         exportVariable('MISE_CARGO_HOME', cargoHome);
     }
     await fs.promises.mkdir(rustupHome, { recursive: true });

--- a/dist/index.js
+++ b/dist/index.js
@@ -88916,11 +88916,12 @@ const MISE_CONFIG_FILE_PATTERNS = [
     `**/.tool-versions`
 ];
 // Default cache key template
-const DEFAULT_CACHE_KEY_TEMPLATE = '{{cache_key_prefix}}-{{platform}}{{#if version}}-{{version}}{{/if}}{{#if mise_env}}-{{mise_env}}{{/if}}{{#if install_args_hash}}-{{install_args_hash}}{{/if}}-{{#if file_hash}}{{file_hash}}{{else}}no-config{{/if}}';
+const DEFAULT_CACHE_KEY_TEMPLATE = '{{cache_key_prefix}}-{{platform}}{{#if cache_rust}}-rust{{/if}}{{#if version}}-{{version}}{{/if}}{{#if mise_env}}-{{mise_env}}{{/if}}{{#if install_args_hash}}-{{install_args_hash}}{{/if}}-{{#if file_hash}}{{file_hash}}{{else}}no-config{{/if}}';
 async function run() {
     try {
         await setToolVersions();
         await setMiseToml();
+        setupRustCache();
         let cacheKey;
         if (getBooleanInput('cache')) {
             cacheKey = await restoreMiseCache();
@@ -89009,6 +89010,45 @@ function setupWings() {
             'mise falls through to direct-origin fetches and the cache ' +
             'is bypassed.');
     }
+}
+/**
+ * Opt in to caching Rust toolchains that mise installs through rustup.
+ *
+ * mise's Rust backend delegates installation to rustup. By default, rustup
+ * stores toolchains in ~/.rustup and its proxies in ~/.cargo/bin, while this
+ * action's normal cache only stores miseDir(). Restoring only miseDir() can
+ * leave the cached mise install marker in place while rustup components such
+ * as rustfmt or clippy are missing from the runner.
+ *
+ * When `cache_rust: true`, put mise-managed Rust state under miseDir() via
+ * mise-specific env vars. This keeps the default behavior unchanged for
+ * workflows that use rust-cache, rustup, setup-rust-toolchain, or another
+ * Rust setup action outside of mise.
+ */
+function setupRustCache() {
+    if (!getBooleanInput('cache_rust')) {
+        return;
+    }
+    if (!getBooleanInput('cache')) {
+        warning('cache_rust is enabled, but cache is false. Rust cache setup is skipped.');
+        return;
+    }
+    const { rustupHome, cargoHome } = rustCacheHomes();
+    if (process.env.MISE_RUSTUP_HOME) {
+        info(`mise rust cache: using MISE_RUSTUP_HOME=${rustupHome}`);
+    }
+    else {
+        exportVariable('MISE_RUSTUP_HOME', rustupHome);
+    }
+    if (process.env.MISE_CARGO_HOME) {
+        info(`mise rust cache: using MISE_CARGO_HOME=${cargoHome}`);
+    }
+    else {
+        exportVariable('MISE_CARGO_HOME', cargoHome);
+    }
+    fs.mkdirSync(rustupHome, { recursive: true });
+    fs.mkdirSync(cargoHome, { recursive: true });
+    info('mise rust cache: enabled. mise-managed rustup and cargo homes will be restored and saved with the mise cache.');
 }
 async function exportMiseEnv() {
     startGroup('Exporting mise environment variables');
@@ -89117,12 +89157,13 @@ async function setEnvVars() {
 async function restoreMiseCache() {
     startGroup('Restoring mise cache');
     const cachePath = miseDir();
+    const cachePaths = miseCachePaths();
     // Use custom cache key if provided, otherwise use default template
     const cacheKeyTemplate = getInput('cache_key') || DEFAULT_CACHE_KEY_TEMPLATE;
     const primaryKey = await processCacheKeyTemplate(cacheKeyTemplate);
     saveState('PRIMARY_KEY', primaryKey);
     saveState('MISE_DIR', cachePath);
-    const cacheKey = await restoreCache([cachePath], primaryKey);
+    const cacheKey = await restoreCache(cachePaths, primaryKey);
     setOutput('cache-hit', Boolean(cacheKey));
     if (!cacheKey) {
         info(`mise cache not found for ${primaryKey}`);
@@ -89280,16 +89321,49 @@ function miseDir() {
         return path$1.join(LOCALAPPDATA, 'mise');
     return path$1.join(os.homedir(), '.local', 'share', 'mise');
 }
+function rustCacheHomes() {
+    const cacheRoot = miseDir();
+    return {
+        rustupHome: process.env.MISE_RUSTUP_HOME || path$1.join(cacheRoot, 'rustup'),
+        cargoHome: process.env.MISE_CARGO_HOME || path$1.join(cacheRoot, 'cargo')
+    };
+}
+function miseCachePaths() {
+    const cacheRoot = miseDir();
+    const cachePaths = [cacheRoot];
+    if (!getBooleanInput('cache_rust')) {
+        return cachePaths;
+    }
+    const { rustupHome, cargoHome } = rustCacheHomes();
+    for (const cachePath of [rustupHome, cargoHome]) {
+        if (!isPathInside(cachePath, cacheRoot) &&
+            !cachePaths.includes(cachePath)) {
+            cachePaths.push(cachePath);
+        }
+    }
+    return cachePaths;
+}
+function isPathInside(child, parent) {
+    const relative = path$1.relative(path$1.resolve(parent), path$1.resolve(child));
+    return (relative === '' ||
+        (!!relative && !relative.startsWith('..') && !path$1.isAbsolute(relative)));
+}
 async function saveCache(cacheKey) {
     await group(`Saving mise cache`, async () => {
         const cachePath = miseDir();
+        const cachePaths = miseCachePaths();
         if (!fs.existsSync(cachePath)) {
             throw new Error(`Cache folder path does not exist on disk: ${cachePath}`);
         }
-        const cacheId = await saveCache$1([cachePath], cacheKey);
+        const existingCachePaths = cachePaths.filter(fs.existsSync);
+        const missingCachePaths = cachePaths.filter(p => !fs.existsSync(p));
+        if (missingCachePaths.length > 0) {
+            info(`Skipping missing cache paths: ${missingCachePaths.join(', ')}`);
+        }
+        const cacheId = await saveCache$1(existingCachePaths, cacheKey);
         if (cacheId === -1)
             return;
-        info(`Cache saved from ${cachePath} with key: ${cacheKey}`);
+        info(`Cache saved from ${existingCachePaths.join(', ')} with key: ${cacheKey}`);
     });
 }
 async function getTarget() {
@@ -89321,6 +89395,7 @@ async function processCacheKeyTemplate(template) {
     const version = getInput('version');
     const installArgs = getInput('install_args');
     const cacheKeyPrefix = getInput('cache_key_prefix') || 'mise-v1';
+    const cacheRust = getBooleanInput('cache_rust');
     const miseEnv = process.env.MISE_ENV?.replace(/,/g, '-');
     const platform = `${await getTarget()}-${getRunnerImageId()}`;
     // Calculate file hash
@@ -89344,7 +89419,8 @@ async function processCacheKeyTemplate(template) {
         platform,
         file_hash: fileHash,
         mise_env: miseEnv,
-        install_args_hash: installArgsHash
+        install_args_hash: installArgsHash,
+        cache_rust: cacheRust
     };
     // Calculate the default cache key by processing the default template
     const defaultTemplate = libExports.compile(DEFAULT_CACHE_KEY_TEMPLATE);

--- a/dist/index.js
+++ b/dist/index.js
@@ -88921,7 +88921,7 @@ async function run() {
     try {
         await setToolVersions();
         await setMiseToml();
-        setupRustCache();
+        await setupRustCache();
         let cacheKey;
         if (getBooleanInput('cache')) {
             cacheKey = await restoreMiseCache();
@@ -89025,7 +89025,7 @@ function setupWings() {
  * workflows that use rust-cache, rustup, setup-rust-toolchain, or another
  * Rust setup action outside of mise.
  */
-function setupRustCache() {
+async function setupRustCache() {
     if (!getBooleanInput('cache_rust')) {
         return;
     }
@@ -89046,8 +89046,8 @@ function setupRustCache() {
     else {
         exportVariable('MISE_CARGO_HOME', cargoHome);
     }
-    fs.mkdirSync(rustupHome, { recursive: true });
-    fs.mkdirSync(cargoHome, { recursive: true });
+    await fs.promises.mkdir(rustupHome, { recursive: true });
+    await fs.promises.mkdir(cargoHome, { recursive: true });
     info('mise rust cache: enabled. mise-managed rustup and cargo homes will be restored and saved with the mise cache.');
 }
 async function exportMiseEnv() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,18 +167,25 @@ async function setupRustCache(): Promise<void> {
     )
     return
   }
+  if (!core.getBooleanInput('cache_save')) {
+    core.warning(
+      'cache_rust is enabled, but cache_save is false. Rust cache paths will be restored for this run but not saved.'
+    )
+  }
 
   const { rustupHome, cargoHome } = rustCacheHomes()
 
   if (process.env.MISE_RUSTUP_HOME) {
-    core.info(`mise rust cache: using MISE_RUSTUP_HOME=${rustupHome}`)
+    core.info(`mise rust cache: using pre-set MISE_RUSTUP_HOME=${rustupHome}`)
   } else {
+    core.info(`mise rust cache: exporting MISE_RUSTUP_HOME=${rustupHome}`)
     core.exportVariable('MISE_RUSTUP_HOME', rustupHome)
   }
 
   if (process.env.MISE_CARGO_HOME) {
-    core.info(`mise rust cache: using MISE_CARGO_HOME=${cargoHome}`)
+    core.info(`mise rust cache: using pre-set MISE_CARGO_HOME=${cargoHome}`)
   } else {
+    core.info(`mise rust cache: exporting MISE_CARGO_HOME=${cargoHome}`)
     core.exportVariable('MISE_CARGO_HOME', cargoHome)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,12 +40,13 @@ const MISE_CONFIG_FILE_PATTERNS = [
 
 // Default cache key template
 const DEFAULT_CACHE_KEY_TEMPLATE =
-  '{{cache_key_prefix}}-{{platform}}{{#if version}}-{{version}}{{/if}}{{#if mise_env}}-{{mise_env}}{{/if}}{{#if install_args_hash}}-{{install_args_hash}}{{/if}}-{{#if file_hash}}{{file_hash}}{{else}}no-config{{/if}}'
+  '{{cache_key_prefix}}-{{platform}}{{#if cache_rust}}-rust{{/if}}{{#if version}}-{{version}}{{/if}}{{#if mise_env}}-{{mise_env}}{{/if}}{{#if install_args_hash}}-{{install_args_hash}}{{/if}}-{{#if file_hash}}{{file_hash}}{{else}}no-config{{/if}}'
 
 async function run(): Promise<void> {
   try {
     await setToolVersions()
     await setMiseToml()
+    setupRustCache()
 
     let cacheKey: string | undefined
     if (core.getBooleanInput('cache')) {
@@ -139,6 +140,54 @@ function setupWings(): void {
         'is bypassed.'
     )
   }
+}
+
+/**
+ * Opt in to caching Rust toolchains that mise installs through rustup.
+ *
+ * mise's Rust backend delegates installation to rustup. By default, rustup
+ * stores toolchains in ~/.rustup and its proxies in ~/.cargo/bin, while this
+ * action's normal cache only stores miseDir(). Restoring only miseDir() can
+ * leave the cached mise install marker in place while rustup components such
+ * as rustfmt or clippy are missing from the runner.
+ *
+ * When `cache_rust: true`, put mise-managed Rust state under miseDir() via
+ * mise-specific env vars. This keeps the default behavior unchanged for
+ * workflows that use rust-cache, rustup, setup-rust-toolchain, or another
+ * Rust setup action outside of mise.
+ */
+function setupRustCache(): void {
+  if (!core.getBooleanInput('cache_rust')) {
+    return
+  }
+
+  if (!core.getBooleanInput('cache')) {
+    core.warning(
+      'cache_rust is enabled, but cache is false. Rust cache setup is skipped.'
+    )
+    return
+  }
+
+  const { rustupHome, cargoHome } = rustCacheHomes()
+
+  if (process.env.MISE_RUSTUP_HOME) {
+    core.info(`mise rust cache: using MISE_RUSTUP_HOME=${rustupHome}`)
+  } else {
+    core.exportVariable('MISE_RUSTUP_HOME', rustupHome)
+  }
+
+  if (process.env.MISE_CARGO_HOME) {
+    core.info(`mise rust cache: using MISE_CARGO_HOME=${cargoHome}`)
+  } else {
+    core.exportVariable('MISE_CARGO_HOME', cargoHome)
+  }
+
+  fs.mkdirSync(rustupHome, { recursive: true })
+  fs.mkdirSync(cargoHome, { recursive: true })
+
+  core.info(
+    'mise rust cache: enabled. mise-managed rustup and cargo homes will be restored and saved with the mise cache.'
+  )
 }
 
 async function exportMiseEnv(): Promise<void> {
@@ -267,6 +316,7 @@ async function setEnvVars(): Promise<void> {
 async function restoreMiseCache(): Promise<string | undefined> {
   core.startGroup('Restoring mise cache')
   const cachePath = miseDir()
+  const cachePaths = miseCachePaths()
 
   // Use custom cache key if provided, otherwise use default template
   const cacheKeyTemplate =
@@ -276,7 +326,7 @@ async function restoreMiseCache(): Promise<string | undefined> {
   core.saveState('PRIMARY_KEY', primaryKey)
   core.saveState('MISE_DIR', cachePath)
 
-  const cacheKey = await cache.restoreCache([cachePath], primaryKey)
+  const cacheKey = await cache.restoreCache(cachePaths, primaryKey)
   core.setOutput('cache-hit', Boolean(cacheKey))
 
   if (!cacheKey) {
@@ -467,18 +517,64 @@ function miseDir(): string {
   return path.join(os.homedir(), '.local', 'share', 'mise')
 }
 
+function rustCacheHomes(): { rustupHome: string; cargoHome: string } {
+  const cacheRoot = miseDir()
+  return {
+    rustupHome: process.env.MISE_RUSTUP_HOME || path.join(cacheRoot, 'rustup'),
+    cargoHome: process.env.MISE_CARGO_HOME || path.join(cacheRoot, 'cargo')
+  }
+}
+
+function miseCachePaths(): string[] {
+  const cacheRoot = miseDir()
+  const cachePaths = [cacheRoot]
+
+  if (!core.getBooleanInput('cache_rust')) {
+    return cachePaths
+  }
+
+  const { rustupHome, cargoHome } = rustCacheHomes()
+  for (const cachePath of [rustupHome, cargoHome]) {
+    if (
+      !isPathInside(cachePath, cacheRoot) &&
+      !cachePaths.includes(cachePath)
+    ) {
+      cachePaths.push(cachePath)
+    }
+  }
+
+  return cachePaths
+}
+
+function isPathInside(child: string, parent: string): boolean {
+  const relative = path.relative(path.resolve(parent), path.resolve(child))
+  return (
+    relative === '' ||
+    (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative))
+  )
+}
+
 async function saveCache(cacheKey: string): Promise<void> {
   await core.group(`Saving mise cache`, async () => {
     const cachePath = miseDir()
+    const cachePaths = miseCachePaths()
 
     if (!fs.existsSync(cachePath)) {
       throw new Error(`Cache folder path does not exist on disk: ${cachePath}`)
     }
 
-    const cacheId = await cache.saveCache([cachePath], cacheKey)
+    const existingCachePaths = cachePaths.filter(fs.existsSync)
+    const missingCachePaths = cachePaths.filter(p => !fs.existsSync(p))
+    if (missingCachePaths.length > 0) {
+      core.info(`Skipping missing cache paths: ${missingCachePaths.join(', ')}`)
+    }
+
+    const cacheId = await cache.saveCache(existingCachePaths, cacheKey)
     if (cacheId === -1) return
 
-    core.info(`Cache saved from ${cachePath} with key: ${cacheKey}`)
+    core.info(
+      `Cache saved from ${existingCachePaths.join(', ')} with key: ${cacheKey}`
+    )
   })
 }
 
@@ -513,6 +609,7 @@ async function processCacheKeyTemplate(template: string): Promise<string> {
   const version = core.getInput('version')
   const installArgs = core.getInput('install_args')
   const cacheKeyPrefix = core.getInput('cache_key_prefix') || 'mise-v1'
+  const cacheRust = core.getBooleanInput('cache_rust')
   const miseEnv = process.env.MISE_ENV?.replace(/,/g, '-')
   const platform = `${await getTarget()}-${getRunnerImageId()}`
 
@@ -539,7 +636,8 @@ async function processCacheKeyTemplate(template: string): Promise<string> {
     platform,
     file_hash: fileHash,
     mise_env: miseEnv,
-    install_args_hash: installArgsHash
+    install_args_hash: installArgsHash,
+    cache_rust: cacheRust
   }
 
   // Calculate the default cache key by processing the default template

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ async function run(): Promise<void> {
   try {
     await setToolVersions()
     await setMiseToml()
-    setupRustCache()
+    await setupRustCache()
 
     let cacheKey: string | undefined
     if (core.getBooleanInput('cache')) {
@@ -156,7 +156,7 @@ function setupWings(): void {
  * workflows that use rust-cache, rustup, setup-rust-toolchain, or another
  * Rust setup action outside of mise.
  */
-function setupRustCache(): void {
+async function setupRustCache(): Promise<void> {
   if (!core.getBooleanInput('cache_rust')) {
     return
   }
@@ -182,8 +182,8 @@ function setupRustCache(): void {
     core.exportVariable('MISE_CARGO_HOME', cargoHome)
   }
 
-  fs.mkdirSync(rustupHome, { recursive: true })
-  fs.mkdirSync(cargoHome, { recursive: true })
+  await fs.promises.mkdir(rustupHome, { recursive: true })
+  await fs.promises.mkdir(cargoHome, { recursive: true })
 
   core.info(
     'mise rust cache: enabled. mise-managed rustup and cargo homes will be restored and saved with the mise cache.'


### PR DESCRIPTION
## Summary

- add `cache_rust: true` as an explicit opt-in for caching Rust toolchains installed by mise
- when enabled, export `MISE_RUSTUP_HOME` and `MISE_CARGO_HOME` before cache restore/install so rustup toolchains and cargo/rustup proxies are saved with the existing mise cache
- add a `-rust` segment to the default cache key, expose `{{cache_rust}}` to custom cache key templates, document the compatibility tradeoffs, and add a lightweight workflow check for the opt-in path

Fixes https://github.com/jdx/mise-action/issues/215
Addresses https://github.com/jdx/mise-action/issues/184
Refs https://github.com/jdx/mise-action/issues/353

## Research notes

### Failure mode

The failure mode in #215/#184/#353 is specific to Rust because mise delegates Rust installation to rustup instead of placing the complete toolchain under `~/.local/share/mise/installs` like most tools.

When mise-action restores only the mise data dir, the cached `installs/rust/...` symlink/marker can make `mise install` report that Rust is already installed, while the corresponding rustup toolchain/components are absent from the runner. The next plain `cargo fmt` or `cargo clippy` then goes through rustup, which may auto-install only the base toolchain and fail because `rustfmt`/`clippy` were never restored.

Primary references:

- mise Rust docs: https://mise.jdx.dev/lang/rust.html
- mise Rust backend: https://github.com/jdx/mise/blob/main/src/plugins/core/rust.rs
- rustup env vars: https://rust-lang.github.io/rustup/environment-variables.html
- rustup installation layout: https://rust-lang.github.io/rustup/installation/
- Cargo env vars: https://doc.rust-lang.org/cargo/reference/environment-variables.html
- GitHub runner Rust tools list: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#rust-tools

### What must be restored

Rustup and Cargo split state across two homes:

- `RUSTUP_HOME`: rustup metadata and installed toolchains/components.
- `CARGO_HOME`: cargo/rustup proxy binaries in `bin`, Cargo-installed binary metadata, registry cache, and git dependency cache.

For the mise-action bug, the required restore set is the rustup toolchain/component state plus the proxy binaries that make plain `cargo`, `rustfmt`, and `clippy` resolve to the same mise-managed toolchain after `mise env` exports `RUSTUP_HOME`/`CARGO_HOME`.

### Cache-key scope and Cargo safety

A single mise-action cache key is appropriate for the toolchain/proxy state because the Rust version/components come from mise config and `mise.lock`, which are already part of the default `file_hash` key.

`CARGO_HOME` can also contain Cargo registry and git caches. Those caches are generally correctness-safe because Cargo validates package versions/checksums and refreshes as needed, but they are not ideal to key only by mise config. They can also be large. This PR therefore documents `cache_rust` as a toolchain/proxy cache, not a replacement for Cargo dependency or `target` build caching.

For workflows that need dependency/build caches, the recommended shape is:

- `mise-action` with `cache_rust: true` to restore mise-owned rustup/Cargo proxy state.
- `Swatinem/rust-cache` after mise-action to manage Cargo registry, git dependency, and `target` caches using Rust/Cargo lockfile-aware keys.
- `cache-bin: "false"` on rust-cache when mise should remain the owner of cargo/rustup proxy binaries and Cargo tools installed by mise.

Related rust-cache docs:

- README: https://github.com/Swatinem/rust-cache/blob/master/README.md
- action inputs: https://github.com/Swatinem/rust-cache/blob/master/action.yml

### Workarounds found in issue/PR references

I checked the cross-reference timelines for #215, #184, and #353, then followed code-search references to their workflow workarounds.

Direct issue/PR references:

- #184 reported missing `cargo-clippy`; commenters found that disabling mise-action cache made mise install clippy correctly, and suggested caching `~/.rustup` plus cargo paths.
- #215 reported the same cached-run `cargo fmt` failure; `cache: false` fixed it by forcing a fresh rustup install with `rustfmt`/`clippy`.
- #353 is a duplicate `cargo fmt` cached-run failure with `profile = "default"`.
- fang2hou/wow-sharedmedia#23 documents `cache: false` on mise-action plus explicit `rustup component add` as the workaround: https://github.com/fang2hou/wow-sharedmedia/pull/23
- cffnpwr/github-todo-bar#22 replaces Nix/Fenix with mise and works around this by disabling mise-action cache, then manually caching `~/.local/share/mise/installs`, `~/.cargo/bin`, and `~/.rustup`: https://github.com/cffnpwr/github-todo-bar/pull/22

Additional public workflow workarounds:

- nikobockerman/mindrig-style composite action: put `RUSTUP_HOME` under `MISE_DATA_DIR`, use a temporary `CARGO_HOME` during mise install, then move Cargo home for later use: https://github.com/nikobockerman/github-actions/blob/main/.github/actions/mise-project-setup/action.yaml
- cffnpwr/github-todo-bar setup action: manual `actions/cache` for mise installs, `~/.cargo/bin`, and `~/.rustup`; mise-action `cache: false`: https://github.com/cffnpwr/github-todo-bar/blob/7925e5f6c4c0a527713ba17080a5de1781b54523/.github/actions/setup-mise/action.yaml
- kossnocorp/nmcr and mdpm: manual cache for `~/.cargo/bin`, `~/.cargo/binstall`, `~/.cargo/env`, `~/.rustup`, followed by `mise exec rust -- rustup component add rustfmt clippy`: https://github.com/kossnocorp/nmcr/blob/e72a04e51e0c5e5f6790be2687d32fdcea574124/.github/workflows/ci.yml
- sargunv projects: run `rustup component add clippy rustfmt` after mise, then separately cache Cargo registry/git/target: https://github.com/sargunv/has-nerd-font/blob/7f3914bb19941533fd73b02016dfb778a7cfae2a/.github/actions/setup/action.yml
- melonswork/ironsubst: cache `~/.rustup/toolchains`, use `Swatinem/rust-cache`, and still run `rustup component add rustfmt clippy llvm-tools-preview`: https://github.com/melonswork/ironsubst/blob/59a899cdb552bfa98096121eccf57e85a334617c/.github/workflows/ci.yml

These workarounds all point to the same missing primitive: mise-action needs an opt-in way to restore the rustup toolchain home and the Cargo proxy/bin home together with the mise install marker.

## Downstream verification

Verified in risu729/biwa#606: https://github.com/risu729/biwa/pull/606

That PR removed the existing `mise install --locked rust --force` workaround, enabled `cache_rust: true`, and combined this action with `Swatinem/rust-cache`.

Evidence from the retry run on the PR branch:

- CI run: https://github.com/risu729/biwa/actions/runs/25633217083
- `Lint` job restored a mise cache key containing `-rust`: `mise-v1-linux-x64-ubuntu24-rust-2026.5.5-13c29379e886bda7bbab6becd116612e36e434b18dc6a761629fce60be0103f7-release`
- the same job exported `CARGO_HOME=/home/runner/.local/share/mise/cargo` and `RUSTUP_HOME=/home/runner/.local/share/mise/rustup`
- `cargo clippy --all-targets -- --deny warnings` and `cargo fmt --check` both passed without the force reinstall workaround
- `Test` restored the same `-rust` mise cache and also restored rust-cache's separate Cargo cache

Evidence after #606 was merged to `main`:

- CI run: https://github.com/risu729/biwa/actions/runs/25646318121
- `Lint` job got an exact mise cache hit for `mise-v1-linux-x64-ubuntu24-rust-2026.5.5-13c29379e886bda7bbab6becd116612e36e434b18dc6a761629fce60be0103f7`
- the job then ran `mise install --locked`, `cargo clippy --all-targets -- --deny warnings`, and `cargo fmt --check` successfully
- `Swatinem/rust-cache` restored a separate cache keyed from Rust/Cargo environment and lockfiles, showing the two caches can coexist

The functional verification used commit `f2054108d3926f722fd54c7fc70a1224cb691032`. Later commits update documentation/action metadata, merge current `upstream/main`, regenerate `dist` against the merged lockfile, and make the `rust_cache_setup` smoke test derive its expected mise data dir instead of hardcoding `$HOME/.local/share/mise`. The runtime Rust cache implementation is unchanged after the verified commit.

## Compatibility and cache behavior

Default behavior is unchanged. `cache_rust` defaults to `false`, so existing workflows keep the same cache paths, cache keys, and environment unless they opt in.

When `cache_rust: true`, this action uses mise-specific settings (`MISE_RUSTUP_HOME`, `MISE_CARGO_HOME`) instead of setting generic `RUSTUP_HOME`/`CARGO_HOME` for everyone. That keeps setup scoped to Rust as managed by mise and avoids silently taking over workflows that install Rust through rustup, setup-rust-toolchain, or another Rust setup action while using mise for unrelated tools.

The default cache key gains `-rust` only when the option is enabled. This avoids restoring older mise-only caches where the `installs/rust/...` marker exists but the rustup/cargo homes were never cached. Users with a custom `cache_key` should include `{{cache_rust}}` or manually invalidate their key when enabling this option.

The current workaround, `mise install --locked rust --force` or `rustup component add rustfmt clippy` after cache restore, should no longer be needed once `cache_rust: true` has produced a Rust-enabled cache entry.

## Test plan

- [x] `npm run all`
- [x] `actionlint .github/workflows/test.yml`
- [x] `git diff --check`
- [x] downstream verification in risu729/biwa#606, including restored-cache retry and post-merge `main` run