### PR TITLE
fix(ci): add gh auth setup-git to release-plz.sh

### DIFF
--- a/scripts/release-plz.sh
+++ b/scripts/release-plz.sh
@@ -47,6 +47,11 @@ if [ -n "$latest_release_version" ] && [ "$cur_pkg_version" = "$latest_release_v
 	git config user.name mise-en-dev
 	git config user.email 123107610+mise-en-dev@users.noreply.github.com
 
+	# Configure git to use gh's credential helper. The checkout step uses
+	# persist-credentials: false (per zizmor's artipacked audit), so the
+	# token isn't written to .git/config and raw `git push` would 403.
+	gh auth setup-git
+
 	# Create a PR with the version bump
 	npm version "${version#v}" --no-git-tag-version
 


### PR DESCRIPTION
## Summary
- Follow-up to [#471](https://github.com/jdx/mise-action/pull/471): the release-plz checkout now uses `persist-credentials: false`, so the token isn't written to `.git/config` and `git push origin release --force` in [scripts/release-plz.sh](scripts/release-plz.sh) would 403.
- Mirror the workaround already applied to [scripts/postversion.sh:9](scripts/postversion.sh:9) by calling `gh auth setup-git` after the `git config user.{name,email}` block, before any `git push`.

Flagged by Cursor Bugbot on https://github.com/jdx/mise-action/pull/471#pullrequestreview-4275760577.

## Test plan
- [ ] Next scheduled release-plz run (or manual `workflow_dispatch`) successfully pushes the `release` branch without a 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that affects the release automation path; main impact is whether the workflow can successfully push the `release` branch.
> 
> **Overview**
> Fixes the `scripts/release-plz.sh` release automation to run `gh auth setup-git` after setting the git author, ensuring `git push` works when `actions/checkout` uses `persist-credentials: false`.
> 
> This prevents 403 failures when pushing the forced `release` branch during automated version bump PR creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f69419101e5564e4dfb377c8d2e7a2981158f4f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->