### PR TITLE
fix(cache): exclude rust from mise cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,11 @@ This gives you full control over cache invalidation based on the specific aspect
 
 ### Rust and Cargo Caches
 
-This action caches mise's own data, but it is not a replacement for a Cargo-aware
-cache. For Rust projects, cache Cargo dependencies, build artifacts, and
-Cargo-installed tools explicitly.
+This action caches mise's own data, but it does not save Rust toolchains.
+According to [mise's Rust documentation](https://mise.jdx.dev/lang/rust.html),
+Rust is managed by rustup, uses `RUSTUP_HOME` and `CARGO_HOME`, and does not live
+under mise's `installs` directory. For Rust projects, cache Cargo dependencies,
+build artifacts, and Cargo-installed tools explicitly.
 
 The usual setup is to run `Swatinem/rust-cache` after `mise-action`, so the cache
 key can include the Rust/Cargo environment and Cargo lockfiles:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ You can also extend the default cache key:
 
 This gives you full control over cache invalidation based on the specific aspects that matter to your workflow.
 
+### Rust and Cargo Caches
+
+This action caches mise's own data, but it is not a replacement for a Cargo-aware
+cache. For Rust projects, cache Cargo dependencies, build artifacts, and
+Cargo-installed tools explicitly.
+
+The usual setup is to run `Swatinem/rust-cache` after `mise-action`, so the cache
+key can include the Rust/Cargo environment and Cargo lockfiles:
+
+```yaml
+- uses: jdx/mise-action@v4
+  with:
+    install: true
+
+- uses: Swatinem/rust-cache@v2
+```
+
+`Swatinem/rust-cache` caches `~/.cargo` and `target` by default, including
+`~/.cargo/bin` for tools installed during the workflow. If your workflow uses a
+custom `CARGO_HOME`, or installs Cargo tools somewhere else, add that directory
+to your cache configuration manually.
+
 ## GitHub API Rate Limits
 
 When installing tools hosted on GitHub (like `gh`, `node`, `bun`, etc.), mise needs to make API calls to GitHub's releases API. Without authentication, these calls are subject to GitHub's rate limit of 60 requests per hour, which can cause installation failures.

--- a/dist/index.js
+++ b/dist/index.js
@@ -89243,6 +89243,7 @@ const MISE_CONFIG_FILE_PATTERNS = [
 ];
 // Default cache key template
 const DEFAULT_CACHE_KEY_TEMPLATE = '{{cache_key_prefix}}-{{platform}}{{#if version}}-{{version}}{{/if}}{{#if mise_env}}-{{mise_env}}{{/if}}{{#if install_args_hash}}-{{install_args_hash}}{{/if}}-{{#if file_hash}}{{file_hash}}{{else}}no-config{{/if}}';
+const RUST_CACHE_PATHS = [path$1.join('installs', 'rust')];
 async function run() {
     try {
         await setToolVersions();
@@ -89612,11 +89613,38 @@ async function saveCache(cacheKey) {
         if (!fs.existsSync(cachePath)) {
             throw new Error(`Cache folder path does not exist on disk: ${cachePath}`);
         }
-        const cacheId = await saveCache$1([cachePath], cacheKey);
-        if (cacheId === -1)
-            return;
-        info(`Cache saved from ${cachePath} with key: ${cacheKey}`);
+        const excludedPaths = await stageRustCachePaths(cachePath);
+        try {
+            const cacheId = await saveCache$1([cachePath], cacheKey);
+            if (cacheId === -1)
+                return;
+            info(`Cache saved from ${cachePath} with key: ${cacheKey}`);
+        }
+        finally {
+            await restoreRustCachePaths(excludedPaths);
+        }
     });
+}
+async function stageRustCachePaths(cachePath) {
+    const stagedPaths = [];
+    for (const relativePath of RUST_CACHE_PATHS) {
+        const originalPath = path$1.join(cachePath, relativePath);
+        if (!fs.existsSync(originalPath))
+            continue;
+        const stagedPath = path$1.join(path$1.dirname(cachePath), `${path$1.basename(cachePath)}-excluded-${relativePath.replaceAll(path$1.sep, '-')}-${process.pid}-${Date.now()}`);
+        info(`Excluding ${originalPath} from mise cache`);
+        await fs.promises.rename(originalPath, stagedPath);
+        stagedPaths.push({ originalPath, stagedPath });
+    }
+    return stagedPaths;
+}
+async function restoreRustCachePaths(stagedPaths) {
+    for (const { originalPath, stagedPath } of stagedPaths.reverse()) {
+        if (!fs.existsSync(stagedPath))
+            continue;
+        await fs.promises.mkdir(path$1.dirname(originalPath), { recursive: true });
+        await fs.promises.rename(stagedPath, originalPath);
+    }
 }
 async function getTarget() {
     const arch = process.arch === 'arm' ? 'armv7' : process.arch;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,8 @@ const MISE_CONFIG_FILE_PATTERNS = [
 const DEFAULT_CACHE_KEY_TEMPLATE =
   '{{cache_key_prefix}}-{{platform}}{{#if version}}-{{version}}{{/if}}{{#if mise_env}}-{{mise_env}}{{/if}}{{#if install_args_hash}}-{{install_args_hash}}{{/if}}-{{#if file_hash}}{{file_hash}}{{else}}no-config{{/if}}'
 
+const RUST_CACHE_PATHS = [path.join('installs', 'rust')]
+
 async function run(): Promise<void> {
   try {
     await setToolVersions()
@@ -475,11 +477,54 @@ async function saveCache(cacheKey: string): Promise<void> {
       throw new Error(`Cache folder path does not exist on disk: ${cachePath}`)
     }
 
-    const cacheId = await cache.saveCache([cachePath], cacheKey)
-    if (cacheId === -1) return
+    const excludedPaths = await stageRustCachePaths(cachePath)
+    try {
+      const cacheId = await cache.saveCache([cachePath], cacheKey)
+      if (cacheId === -1) return
 
-    core.info(`Cache saved from ${cachePath} with key: ${cacheKey}`)
+      core.info(`Cache saved from ${cachePath} with key: ${cacheKey}`)
+    } finally {
+      await restoreRustCachePaths(excludedPaths)
+    }
   })
+}
+
+type StagedCachePath = {
+  originalPath: string
+  stagedPath: string
+}
+
+async function stageRustCachePaths(
+  cachePath: string
+): Promise<StagedCachePath[]> {
+  const stagedPaths: StagedCachePath[] = []
+
+  for (const relativePath of RUST_CACHE_PATHS) {
+    const originalPath = path.join(cachePath, relativePath)
+    if (!fs.existsSync(originalPath)) continue
+
+    const stagedPath = path.join(
+      path.dirname(cachePath),
+      `${path.basename(cachePath)}-excluded-${relativePath.replaceAll(path.sep, '-')}-${process.pid}-${Date.now()}`
+    )
+
+    core.info(`Excluding ${originalPath} from mise cache`)
+    await fs.promises.rename(originalPath, stagedPath)
+    stagedPaths.push({ originalPath, stagedPath })
+  }
+
+  return stagedPaths
+}
+
+async function restoreRustCachePaths(
+  stagedPaths: StagedCachePath[]
+): Promise<void> {
+  for (const { originalPath, stagedPath } of stagedPaths.reverse()) {
+    if (!fs.existsSync(stagedPath)) continue
+
+    await fs.promises.mkdir(path.dirname(originalPath), { recursive: true })
+    await fs.promises.rename(stagedPath, originalPath)
+  }
 }
 
 async function getTarget(): Promise<string> {


### PR DESCRIPTION
## Summary

- exclude mise-managed Rust installs from the saved mise-action cache
- restore the Rust install path after saving so later workflow steps can still use it
- document that mise-action does not save Rust toolchains and recommend a Cargo-aware cache for Rust projects

## Notes

`@actions/cache.saveCache` does not support per-path exclusions when saving a cache path. To keep the current job behavior intact, this PR temporarily stages `installs/rust` outside `MISE_DATA_DIR`, saves the mise cache, then restores it in a `finally` block.

I checked the mise Rust backend: `downloads/rust` is not read as a reusable cache. Rust installs go through rustup, rustup state lives under `RUSTUP_HOME`/`CARGO_HOME`, and mise only creates `downloads/rust/<version>` via generic install scaffolding. That directory is removed after successful install unless `always_keep_download` is enabled, where it is retained for debugging rather than reuse.

This replaces the previous docs-only approach after the mise-side fix was declined.

## Test plan

- [x] `npm run format:write`
- [x] `npm run lint`
- [x] `npm run package`

*This PR body was generated by an AI coding assistant.*