### PR TITLE
fix: install mise-shim.exe on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,15 @@ jobs:
       - run: mise x jq -- jq --version
       - run: which jq
       - run: jq --version
+      - name: Check Windows shim binary
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $miseBinDir = Split-Path -Parent (Get-Command mise).Source
+          $miseShim = Join-Path $miseBinDir "mise-shim.exe"
+          if (!(Test-Path -LiteralPath $miseShim)) {
+            throw "mise-shim.exe was not installed next to mise.exe"
+          }
       - run: . scripts/test.sh
         shell: bash
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -89460,6 +89460,7 @@ async function setupMise(version, fetchFromGitHub = false) {
     const miseBinDir = path$1.join(miseDir(), 'bin');
     const miseBinPath = path$1.join(miseBinDir, process.platform === 'win32' ? 'mise.exe' : 'mise');
     const miseShimPath = path$1.join(miseBinDir, 'mise-shim.exe');
+    let installedVersion;
     if (!fs.existsSync(path$1.join(miseBinPath))) {
         startGroup(version ? `Download mise@${version}` : 'Setup mise');
         await fs.promises.mkdir(miseBinDir, { recursive: true });
@@ -89480,20 +89481,14 @@ async function setupMise(version, fetchFromGitHub = false) {
         else {
             url = `https://github.com/jdx/mise/releases/download/v${resolvedVersion}/mise-v${resolvedVersion}-${await getTarget()}${ext}`;
         }
-        const archivePath = path$1.join(os.tmpdir(), `mise${ext}`);
+        installedVersion = resolvedVersion;
         switch (ext) {
             case '.zip': {
-                await exec('curl', ['-fsSL', url, '--output', archivePath]);
-                const extractDir = await fs.promises.mkdtemp(path$1.join(os.tmpdir(), 'mise-action-'));
-                try {
-                    await exec('unzip', [archivePath, '-d', extractDir]);
+                await withExtractedZip(url, 'mise.zip', async (extractDir) => {
                     const extractedMiseBinDir = path$1.join(extractDir, 'mise', 'bin');
                     await mv(path$1.join(extractedMiseBinDir, 'mise.exe'), miseBinPath);
                     await installWindowsMiseShim(extractedMiseBinDir, miseShimPath);
-                }
-                finally {
-                    await rmRF(extractDir);
-                }
+                });
                 break;
             }
             case '.tar.zst':
@@ -89517,7 +89512,7 @@ async function setupMise(version, fetchFromGitHub = false) {
     else {
         const requestedVersion = cleanVersion(getInput('version'));
         if (requestedVersion !== '') {
-            const installedVersion = await getInstalledMiseVersion(miseBinPath);
+            installedVersion = await getInstalledMiseVersion(miseBinPath);
             if (requestedVersion === installedVersion) {
                 info(`mise already installed`);
             }
@@ -89525,10 +89520,11 @@ async function setupMise(version, fetchFromGitHub = false) {
                 info(`mise already installed (${installedVersion}), but different version requested (${requestedVersion})`);
                 await exec(miseBinPath, ['self-update', requestedVersion, '-y']);
                 info(`mise updated to version ${requestedVersion}`);
+                installedVersion = requestedVersion;
             }
         }
     }
-    await ensureWindowsMiseShim(miseBinPath, miseShimPath);
+    await ensureWindowsMiseShim(miseBinPath, miseShimPath, installedVersion);
     // compare with provided hash
     const want = getInput('sha256');
     if (want) {
@@ -89541,6 +89537,19 @@ async function setupMise(version, fetchFromGitHub = false) {
     }
     addPath(miseBinDir);
 }
+async function withExtractedZip(url, archiveName, fn) {
+    const tempDir = await fs.promises.mkdtemp(path$1.join(os.tmpdir(), 'mise-action-'));
+    try {
+        const archivePath = path$1.join(tempDir, archiveName);
+        const extractDir = path$1.join(tempDir, 'extract');
+        await exec('curl', ['-fsSL', url, '--output', archivePath]);
+        await exec('unzip', [archivePath, '-d', extractDir]);
+        await fn(extractDir);
+    }
+    finally {
+        await rmRF(tempDir);
+    }
+}
 async function installWindowsMiseShim(extractedMiseBinDir, miseShimPath) {
     if (process.platform !== 'win32')
         return;
@@ -89551,31 +89560,22 @@ async function installWindowsMiseShim(extractedMiseBinDir, miseShimPath) {
     }
     await mv(extractedMiseShimPath, miseShimPath);
 }
-async function ensureWindowsMiseShim(miseBinPath, miseShimPath) {
+async function ensureWindowsMiseShim(miseBinPath, miseShimPath, version) {
     if (process.platform !== 'win32')
         return;
     if (fs.existsSync(miseShimPath))
         return;
     info('mise-shim.exe not found next to mise.exe; installing it from the matching release archive');
-    let tempDir;
     try {
-        const installedVersion = await getInstalledMiseVersion(miseBinPath);
+        const installedVersion = version || (await getInstalledMiseVersion(miseBinPath));
         const archiveName = `mise-v${installedVersion}-${await getTarget()}.zip`;
         const url = `https://github.com/jdx/mise/releases/download/v${installedVersion}/${archiveName}`;
-        tempDir = await fs.promises.mkdtemp(path$1.join(os.tmpdir(), 'mise-action-'));
-        const archivePath = path$1.join(tempDir, archiveName);
-        const extractDir = path$1.join(tempDir, 'extract');
-        await exec('curl', ['-fsSL', url, '--output', archivePath]);
-        await exec('unzip', [archivePath, '-d', extractDir]);
-        await installWindowsMiseShim(path$1.join(extractDir, 'mise', 'bin'), miseShimPath);
+        await withExtractedZip(url, archiveName, async (extractDir) => {
+            await installWindowsMiseShim(path$1.join(extractDir, 'mise', 'bin'), miseShimPath);
+        });
     }
     catch (err) {
-        warning(`Failed to install mise-shim.exe: ${errorMessage(err)}`);
-    }
-    finally {
-        if (tempDir) {
-            await rmRF(tempDir);
-        }
+        warning(`Failed to install mise-shim.exe: ${errorMessage(err)}. Continuing because mise can fall back to file shim mode on Windows.`);
     }
 }
 async function getInstalledMiseVersion(miseBinPath) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -89459,6 +89459,7 @@ async function restoreMiseCache() {
 async function setupMise(version, fetchFromGitHub = false) {
     const miseBinDir = path$1.join(miseDir(), 'bin');
     const miseBinPath = path$1.join(miseBinDir, process.platform === 'win32' ? 'mise.exe' : 'mise');
+    const miseShimPath = path$1.join(miseBinDir, 'mise-shim.exe');
     if (!fs.existsSync(path$1.join(miseBinPath))) {
         startGroup(version ? `Download mise@${version}` : 'Setup mise');
         await fs.promises.mkdir(miseBinDir, { recursive: true });
@@ -89481,11 +89482,20 @@ async function setupMise(version, fetchFromGitHub = false) {
         }
         const archivePath = path$1.join(os.tmpdir(), `mise${ext}`);
         switch (ext) {
-            case '.zip':
+            case '.zip': {
                 await exec('curl', ['-fsSL', url, '--output', archivePath]);
-                await exec('unzip', [archivePath, '-d', os.tmpdir()]);
-                await mv(path$1.join(os.tmpdir(), 'mise/bin/mise.exe'), miseBinPath);
+                const extractDir = await fs.promises.mkdtemp(path$1.join(os.tmpdir(), 'mise-action-'));
+                try {
+                    await exec('unzip', [archivePath, '-d', extractDir]);
+                    const extractedMiseBinDir = path$1.join(extractDir, 'mise', 'bin');
+                    await mv(path$1.join(extractedMiseBinDir, 'mise.exe'), miseBinPath);
+                    await installWindowsMiseShim(extractedMiseBinDir, miseShimPath);
+                }
+                finally {
+                    await rmRF(extractDir);
+                }
                 break;
+            }
             case '.tar.zst':
                 await exec('sh', [
                     '-c',
@@ -89507,19 +89517,18 @@ async function setupMise(version, fetchFromGitHub = false) {
     else {
         const requestedVersion = cleanVersion(getInput('version'));
         if (requestedVersion !== '') {
-            const versionOutput = await getExecOutput(miseBinPath, ['version', '--json'], { silent: true });
-            const versionJson = JSON.parse(versionOutput.stdout);
-            const version = cleanVersion(versionJson.version.split(' ')[0]);
-            if (requestedVersion === version) {
+            const installedVersion = await getInstalledMiseVersion(miseBinPath);
+            if (requestedVersion === installedVersion) {
                 info(`mise already installed`);
             }
             else {
-                info(`mise already installed (${version}), but different version requested (${requestedVersion})`);
+                info(`mise already installed (${installedVersion}), but different version requested (${requestedVersion})`);
                 await exec(miseBinPath, ['self-update', requestedVersion, '-y']);
                 info(`mise updated to version ${requestedVersion}`);
             }
         }
     }
+    await ensureWindowsMiseShim(miseBinPath, miseShimPath);
     // compare with provided hash
     const want = getInput('sha256');
     if (want) {
@@ -89531,6 +89540,51 @@ async function setupMise(version, fetchFromGitHub = false) {
         }
     }
     addPath(miseBinDir);
+}
+async function installWindowsMiseShim(extractedMiseBinDir, miseShimPath) {
+    if (process.platform !== 'win32')
+        return;
+    const extractedMiseShimPath = path$1.join(extractedMiseBinDir, 'mise-shim.exe');
+    if (!fs.existsSync(extractedMiseShimPath)) {
+        info('mise-shim.exe not found in the mise archive; skipping');
+        return;
+    }
+    await mv(extractedMiseShimPath, miseShimPath);
+}
+async function ensureWindowsMiseShim(miseBinPath, miseShimPath) {
+    if (process.platform !== 'win32')
+        return;
+    if (fs.existsSync(miseShimPath))
+        return;
+    info('mise-shim.exe not found next to mise.exe; installing it from the matching release archive');
+    let tempDir;
+    try {
+        const installedVersion = await getInstalledMiseVersion(miseBinPath);
+        const archiveName = `mise-v${installedVersion}-${await getTarget()}.zip`;
+        const url = `https://github.com/jdx/mise/releases/download/v${installedVersion}/${archiveName}`;
+        tempDir = await fs.promises.mkdtemp(path$1.join(os.tmpdir(), 'mise-action-'));
+        const archivePath = path$1.join(tempDir, archiveName);
+        const extractDir = path$1.join(tempDir, 'extract');
+        await exec('curl', ['-fsSL', url, '--output', archivePath]);
+        await exec('unzip', [archivePath, '-d', extractDir]);
+        await installWindowsMiseShim(path$1.join(extractDir, 'mise', 'bin'), miseShimPath);
+    }
+    catch (err) {
+        warning(`Failed to install mise-shim.exe: ${errorMessage(err)}`);
+    }
+    finally {
+        if (tempDir) {
+            await rmRF(tempDir);
+        }
+    }
+}
+async function getInstalledMiseVersion(miseBinPath) {
+    const versionOutput = await getExecOutput(miseBinPath, ['version', '--json'], { silent: true });
+    const versionJson = JSON.parse(versionOutput.stdout);
+    return cleanVersion(versionJson.version.split(' ')[0]);
+}
+function errorMessage(err) {
+    return err instanceof Error ? err.message : String(err);
 }
 async function zstdInstalled() {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,6 +296,7 @@ async function setupMise(
     miseBinDir,
     process.platform === 'win32' ? 'mise.exe' : 'mise'
   )
+  const miseShimPath = path.join(miseBinDir, 'mise-shim.exe')
   if (!fs.existsSync(path.join(miseBinPath))) {
     core.startGroup(version ? `Download mise@${version}` : 'Setup mise')
     await fs.promises.mkdir(miseBinDir, { recursive: true })
@@ -318,11 +319,21 @@ async function setupMise(
     }
     const archivePath = path.join(os.tmpdir(), `mise${ext}`)
     switch (ext) {
-      case '.zip':
+      case '.zip': {
         await exec.exec('curl', ['-fsSL', url, '--output', archivePath])
-        await exec.exec('unzip', [archivePath, '-d', os.tmpdir()])
-        await io.mv(path.join(os.tmpdir(), 'mise/bin/mise.exe'), miseBinPath)
+        const extractDir = await fs.promises.mkdtemp(
+          path.join(os.tmpdir(), 'mise-action-')
+        )
+        try {
+          await exec.exec('unzip', [archivePath, '-d', extractDir])
+          const extractedMiseBinDir = path.join(extractDir, 'mise', 'bin')
+          await io.mv(path.join(extractedMiseBinDir, 'mise.exe'), miseBinPath)
+          await installWindowsMiseShim(extractedMiseBinDir, miseShimPath)
+        } finally {
+          await io.rmRF(extractDir)
+        }
         break
+      }
       case '.tar.zst':
         await exec.exec('sh', [
           '-c',
@@ -343,24 +354,19 @@ async function setupMise(
   } else {
     const requestedVersion = cleanVersion(core.getInput('version'))
     if (requestedVersion !== '') {
-      const versionOutput = await exec.getExecOutput(
-        miseBinPath,
-        ['version', '--json'],
-        { silent: true }
-      )
-      const versionJson = JSON.parse(versionOutput.stdout)
-      const version = cleanVersion(versionJson.version.split(' ')[0])
-      if (requestedVersion === version) {
+      const installedVersion = await getInstalledMiseVersion(miseBinPath)
+      if (requestedVersion === installedVersion) {
         core.info(`mise already installed`)
       } else {
         core.info(
-          `mise already installed (${version}), but different version requested (${requestedVersion})`
+          `mise already installed (${installedVersion}), but different version requested (${requestedVersion})`
         )
         await exec.exec(miseBinPath, ['self-update', requestedVersion, '-y'])
         core.info(`mise updated to version ${requestedVersion}`)
       }
     }
   }
+  await ensureWindowsMiseShim(miseBinPath, miseShimPath)
   // compare with provided hash
   const want = core.getInput('sha256')
   if (want) {
@@ -375,6 +381,71 @@ async function setupMise(
   }
 
   core.addPath(miseBinDir)
+}
+
+async function installWindowsMiseShim(
+  extractedMiseBinDir: string,
+  miseShimPath: string
+): Promise<void> {
+  if (process.platform !== 'win32') return
+
+  const extractedMiseShimPath = path.join(extractedMiseBinDir, 'mise-shim.exe')
+  if (!fs.existsSync(extractedMiseShimPath)) {
+    core.info('mise-shim.exe not found in the mise archive; skipping')
+    return
+  }
+
+  await io.mv(extractedMiseShimPath, miseShimPath)
+}
+
+async function ensureWindowsMiseShim(
+  miseBinPath: string,
+  miseShimPath: string
+): Promise<void> {
+  if (process.platform !== 'win32') return
+  if (fs.existsSync(miseShimPath)) return
+
+  core.info(
+    'mise-shim.exe not found next to mise.exe; installing it from the matching release archive'
+  )
+
+  let tempDir: string | undefined
+  try {
+    const installedVersion = await getInstalledMiseVersion(miseBinPath)
+    const archiveName = `mise-v${installedVersion}-${await getTarget()}.zip`
+    const url = `https://github.com/jdx/mise/releases/download/v${installedVersion}/${archiveName}`
+
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mise-action-'))
+    const archivePath = path.join(tempDir, archiveName)
+    const extractDir = path.join(tempDir, 'extract')
+
+    await exec.exec('curl', ['-fsSL', url, '--output', archivePath])
+    await exec.exec('unzip', [archivePath, '-d', extractDir])
+    await installWindowsMiseShim(
+      path.join(extractDir, 'mise', 'bin'),
+      miseShimPath
+    )
+  } catch (err) {
+    core.warning(`Failed to install mise-shim.exe: ${errorMessage(err)}`)
+  } finally {
+    if (tempDir) {
+      await io.rmRF(tempDir)
+    }
+  }
+}
+
+async function getInstalledMiseVersion(miseBinPath: string): Promise<string> {
+  const versionOutput = await exec.getExecOutput(
+    miseBinPath,
+    ['version', '--json'],
+    { silent: true }
+  )
+  const versionJson = JSON.parse(versionOutput.stdout) as { version: string }
+  return cleanVersion(versionJson.version.split(' ')[0])
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
 }
 
 async function zstdInstalled(): Promise<boolean> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,6 +297,7 @@ async function setupMise(
     process.platform === 'win32' ? 'mise.exe' : 'mise'
   )
   const miseShimPath = path.join(miseBinDir, 'mise-shim.exe')
+  let installedVersion: string | undefined
   if (!fs.existsSync(path.join(miseBinPath))) {
     core.startGroup(version ? `Download mise@${version}` : 'Setup mise')
     await fs.promises.mkdir(miseBinDir, { recursive: true })
@@ -317,21 +318,14 @@ async function setupMise(
     } else {
       url = `https://github.com/jdx/mise/releases/download/v${resolvedVersion}/mise-v${resolvedVersion}-${await getTarget()}${ext}`
     }
-    const archivePath = path.join(os.tmpdir(), `mise${ext}`)
+    installedVersion = resolvedVersion
     switch (ext) {
       case '.zip': {
-        await exec.exec('curl', ['-fsSL', url, '--output', archivePath])
-        const extractDir = await fs.promises.mkdtemp(
-          path.join(os.tmpdir(), 'mise-action-')
-        )
-        try {
-          await exec.exec('unzip', [archivePath, '-d', extractDir])
+        await withExtractedZip(url, 'mise.zip', async extractDir => {
           const extractedMiseBinDir = path.join(extractDir, 'mise', 'bin')
           await io.mv(path.join(extractedMiseBinDir, 'mise.exe'), miseBinPath)
           await installWindowsMiseShim(extractedMiseBinDir, miseShimPath)
-        } finally {
-          await io.rmRF(extractDir)
-        }
+        })
         break
       }
       case '.tar.zst':
@@ -354,7 +348,7 @@ async function setupMise(
   } else {
     const requestedVersion = cleanVersion(core.getInput('version'))
     if (requestedVersion !== '') {
-      const installedVersion = await getInstalledMiseVersion(miseBinPath)
+      installedVersion = await getInstalledMiseVersion(miseBinPath)
       if (requestedVersion === installedVersion) {
         core.info(`mise already installed`)
       } else {
@@ -363,10 +357,11 @@ async function setupMise(
         )
         await exec.exec(miseBinPath, ['self-update', requestedVersion, '-y'])
         core.info(`mise updated to version ${requestedVersion}`)
+        installedVersion = requestedVersion
       }
     }
   }
-  await ensureWindowsMiseShim(miseBinPath, miseShimPath)
+  await ensureWindowsMiseShim(miseBinPath, miseShimPath, installedVersion)
   // compare with provided hash
   const want = core.getInput('sha256')
   if (want) {
@@ -381,6 +376,26 @@ async function setupMise(
   }
 
   core.addPath(miseBinDir)
+}
+
+async function withExtractedZip(
+  url: string,
+  archiveName: string,
+  fn: (extractDir: string) => Promise<void>
+): Promise<void> {
+  const tempDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'mise-action-')
+  )
+  try {
+    const archivePath = path.join(tempDir, archiveName)
+    const extractDir = path.join(tempDir, 'extract')
+
+    await exec.exec('curl', ['-fsSL', url, '--output', archivePath])
+    await exec.exec('unzip', [archivePath, '-d', extractDir])
+    await fn(extractDir)
+  } finally {
+    await io.rmRF(tempDir)
+  }
 }
 
 async function installWindowsMiseShim(
@@ -400,7 +415,8 @@ async function installWindowsMiseShim(
 
 async function ensureWindowsMiseShim(
   miseBinPath: string,
-  miseShimPath: string
+  miseShimPath: string,
+  version?: string
 ): Promise<void> {
   if (process.platform !== 'win32') return
   if (fs.existsSync(miseShimPath)) return
@@ -409,28 +425,22 @@ async function ensureWindowsMiseShim(
     'mise-shim.exe not found next to mise.exe; installing it from the matching release archive'
   )
 
-  let tempDir: string | undefined
   try {
-    const installedVersion = await getInstalledMiseVersion(miseBinPath)
+    const installedVersion =
+      version || (await getInstalledMiseVersion(miseBinPath))
     const archiveName = `mise-v${installedVersion}-${await getTarget()}.zip`
     const url = `https://github.com/jdx/mise/releases/download/v${installedVersion}/${archiveName}`
 
-    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mise-action-'))
-    const archivePath = path.join(tempDir, archiveName)
-    const extractDir = path.join(tempDir, 'extract')
-
-    await exec.exec('curl', ['-fsSL', url, '--output', archivePath])
-    await exec.exec('unzip', [archivePath, '-d', extractDir])
-    await installWindowsMiseShim(
-      path.join(extractDir, 'mise', 'bin'),
-      miseShimPath
-    )
+    await withExtractedZip(url, archiveName, async extractDir => {
+      await installWindowsMiseShim(
+        path.join(extractDir, 'mise', 'bin'),
+        miseShimPath
+      )
+    })
   } catch (err) {
-    core.warning(`Failed to install mise-shim.exe: ${errorMessage(err)}`)
-  } finally {
-    if (tempDir) {
-      await io.rmRF(tempDir)
-    }
+    core.warning(
+      `Failed to install mise-shim.exe: ${errorMessage(err)}. Continuing because mise can fall back to file shim mode on Windows.`
+    )
   }
 }
 


### PR DESCRIPTION
## Summary
- install `mise-shim.exe` beside `mise.exe` when extracting Windows mise release zips
- repair restored Windows caches that have `mise.exe` but are missing `mise-shim.exe`
- add a Windows CI assertion for the installed shim binary

Fixes #475.

## Testing
- `npm run all`
- `actionlint`
