### PR TITLE
fix(ci): pin codeql-action with exact version comment

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,15 +40,15 @@ jobs:
 
       - name: Initialize CodeQL
         id: initialize
-        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           languages: ${{ matrix.language }}
           source-root: src
 
       - name: Autobuild
         id: autobuild
-        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
 
       - name: Perform CodeQL Analysis
         id: analyze
-        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4


### PR DESCRIPTION
## Summary
- Update the `# v4` comments on the three `github/codeql-action/*` SHA pins in `codeql-analysis.yml` to `# v4.35.4`, matching what the pinned SHA actually resolves to.
- Resolves the three `ref-version-mismatch` medium findings that are currently failing the `zizmor` check on every PR.

## Test plan
- [ ] `zizmor` workflow passes on this branch
- [ ] CodeQL workflow still runs (no behavior change — same SHA pinned, only the comment changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in CI workflow; the CodeQL action SHA pins are unchanged so runtime behavior should not change.
> 
> **Overview**
> Updates `.github/workflows/codeql-analysis.yml` to change the inline version comments on the pinned `github/codeql-action` steps (`init`, `autobuild`, `analyze`) from `# v4` to `# v4.35.4`, matching the existing pinned SHA and avoiding version-mismatch lint findings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a600336bf0ba3e885f391affafb14e72d1887c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->