### PR TITLE
chore: release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,34 @@
 # Changelog
 
 ---
+## [4.1.0](https://github.com/jdx/mise-action/compare/v4.0.1..v4.1.0) - 2026-06-04
+
+### 🚀 Features
+
+- add wings_enabled input (mise-wings cache integration) (#454) by [@jdx](https://github.com/jdx) in [#454](https://github.com/jdx/mise-action/pull/454)
+- lock install when mise.lock is present (#495) by [@zeitlinger](https://github.com/zeitlinger) in [#495](https://github.com/jdx/mise-action/pull/495)
+
+### 🐛 Bug Fixes
+
+- **(ci)** add gh auth setup-git to release-plz.sh (#473) by [@jdx](https://github.com/jdx) in [#473](https://github.com/jdx/mise-action/pull/473)
+- **(ci)** pin codeql-action with exact version comment (#481) by [@jdx](https://github.com/jdx) in [#481](https://github.com/jdx/mise-action/pull/481)
+- include runner image in cache key to prevent cross-provider collisions (#456) by [@jdx](https://github.com/jdx) in [#456](https://github.com/jdx/mise-action/pull/456)
+- install mise-shim.exe on Windows (#476) by [@risu729](https://github.com/risu729) in [#476](https://github.com/jdx/mise-action/pull/476)
+
+### ⚙️ Miscellaneous Tasks
+
+- **(ci)** use !cancelled() instead of always() for final job (#460) by [@jdx](https://github.com/jdx) in [#460](https://github.com/jdx/mise-action/pull/460)
+- **(ci)** remove autofix.ci workflow (#470) by [@jdx](https://github.com/jdx) in [#470](https://github.com/jdx/mise-action/pull/470)
+- **(ci)** add zizmor workflow for github actions security analysis (#471) by [@jdx](https://github.com/jdx) in [#471](https://github.com/jdx/mise-action/pull/471)
+- **(ci)** close failing or conflicted PRs sooner (#480) by [@jdx](https://github.com/jdx) in [#480](https://github.com/jdx/mise-action/pull/480)
+- add communique to enhance release notes (#411) by [@jdx](https://github.com/jdx) in [#411](https://github.com/jdx/mise-action/pull/411)
+- migrate from ncc (CJS) to rollup (ESM) (#436) by [@jdx](https://github.com/jdx) in [#436](https://github.com/jdx/mise-action/pull/436)
+- add final job to aggregate build-test results (#438) by [@jdx](https://github.com/jdx) in [#438](https://github.com/jdx/mise-action/pull/438)
+- migrate package manager from npm/pnpm/bun to aube (#455) by [@jdx](https://github.com/jdx) in [#455](https://github.com/jdx/mise-action/pull/455)
+- remove pull_request_target workflow (#469) by [@jdx](https://github.com/jdx) in [#469](https://github.com/jdx/mise-action/pull/469)
+- update aube tool version (#501) by [@jdx](https://github.com/jdx) in [#501](https://github.com/jdx/mise-action/pull/501)
+
+---
 ## [4.0.1](https://github.com/jdx/mise-action/compare/v4.0.0..v4.0.1) - 2026-03-22
 
 ### 🐛 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mise-action",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mise-action",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "author": "jdx",
   "type": "module",
   "private": true,


### PR DESCRIPTION

---
## [4.1.0](https://github.com/jdx/mise-action/compare/v4.0.1..v4.1.0) - 2026-06-04

### 🚀 Features

- add wings_enabled input (mise-wings cache integration) (#454) by [@jdx](https://github.com/jdx) in [#454](https://github.com/jdx/mise-action/pull/454)
- lock install when mise.lock is present (#495) by [@zeitlinger](https://github.com/zeitlinger) in [#495](https://github.com/jdx/mise-action/pull/495)

### 🐛 Bug Fixes

- **(ci)** add gh auth setup-git to release-plz.sh (#473) by [@jdx](https://github.com/jdx) in [#473](https://github.com/jdx/mise-action/pull/473)
- **(ci)** pin codeql-action with exact version comment (#481) by [@jdx](https://github.com/jdx) in [#481](https://github.com/jdx/mise-action/pull/481)
- include runner image in cache key to prevent cross-provider collisions (#456) by [@jdx](https://github.com/jdx) in [#456](https://github.com/jdx/mise-action/pull/456)
- install mise-shim.exe on Windows (#476) by [@risu729](https://github.com/risu729) in [#476](https://github.com/jdx/mise-action/pull/476)

### ⚙️ Miscellaneous Tasks

- **(ci)** use !cancelled() instead of always() for final job (#460) by [@jdx](https://github.com/jdx) in [#460](https://github.com/jdx/mise-action/pull/460)
- **(ci)** remove autofix.ci workflow (#470) by [@jdx](https://github.com/jdx) in [#470](https://github.com/jdx/mise-action/pull/470)
- **(ci)** add zizmor workflow for github actions security analysis (#471) by [@jdx](https://github.com/jdx) in [#471](https://github.com/jdx/mise-action/pull/471)
- **(ci)** close failing or conflicted PRs sooner (#480) by [@jdx](https://github.com/jdx) in [#480](https://github.com/jdx/mise-action/pull/480)
- add communique to enhance release notes (#411) by [@jdx](https://github.com/jdx) in [#411](https://github.com/jdx/mise-action/pull/411)
- migrate from ncc (CJS) to rollup (ESM) (#436) by [@jdx](https://github.com/jdx) in [#436](https://github.com/jdx/mise-action/pull/436)
- add final job to aggregate build-test results (#438) by [@jdx](https://github.com/jdx) in [#438](https://github.com/jdx/mise-action/pull/438)
- migrate package manager from npm/pnpm/bun to aube (#455) by [@jdx](https://github.com/jdx) in [#455](https://github.com/jdx/mise-action/pull/455)
- remove pull_request_target workflow (#469) by [@jdx](https://github.com/jdx) in [#469](https://github.com/jdx/mise-action/pull/469)
- update aube tool version (#501) by [@jdx](https://github.com/jdx) in [#501](https://github.com/jdx/mise-action/pull/501)

<!-- generated by git-cliff -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no modifications to `src/` or `dist/` in this diff.
> 
> **Overview**
> **Release v4.1.0** bumps the package version from `4.0.1` to `4.1.0` in `package.json` and `package-lock.json`, and prepends a **4.1.0** section to `CHANGELOG.md` (git-cliff style) documenting what shipped since v4.0.1.
> 
> The changelog entry highlights user-facing work already merged on main: **`wings_enabled`** (mise-wings cache), **lockfile-driven install** when `mise.lock` exists, cache-key fixes (runner image in key), Windows **`mise-shim.exe`** install, plus CI/tooling (rollup ESM, aube, zizmor, etc.). **This PR does not change action runtime code**—only version metadata and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c370715a7bb046c669a96e1dde8221fa9b2d2961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 4.1.0 and updated release notes entry dated 2026-06-04
  * Bumped package version from 4.0.1 to 4.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->