### PR TITLE
chore: release v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
 ---
+## [4.2.0](https://github.com/jdx/mise-action/compare/v4.1.0..v4.2.0) - 2026-06-17
+
+### 🚀 Features
+
+- support bootstrap mode (#522) by [@jdx](https://github.com/jdx) in [#522](https://github.com/jdx/mise-action/pull/522)
+
+### 🐛 Bug Fixes
+
+- fall back to wget when curl is unavailable (#521) by [@risu729](https://github.com/risu729) in [#521](https://github.com/jdx/mise-action/pull/521)
+
+### 📚 Documentation
+
+- link rust cache issue (#496) by [@risu729](https://github.com/risu729) in [#496](https://github.com/jdx/mise-action/pull/496)
+
+### ⚙️ Miscellaneous Tasks
+
+- **(ci)** fix zizmor version comments (#506) by [@jdx](https://github.com/jdx) in [#506](https://github.com/jdx/mise-action/pull/506)
+- **(ci)** use pr-closer action (#505) by [@jdx](https://github.com/jdx) in [#505](https://github.com/jdx/mise-action/pull/505)
+
+---
 ## [4.1.0](https://github.com/jdx/mise-action/compare/v4.0.1..v4.1.0) - 2026-06-04
 
 ### 🚀 Features
@@ -12,6 +32,7 @@
 
 - **(ci)** add gh auth setup-git to release-plz.sh (#473) by [@jdx](https://github.com/jdx) in [#473](https://github.com/jdx/mise-action/pull/473)
 - **(ci)** pin codeql-action with exact version comment (#481) by [@jdx](https://github.com/jdx) in [#481](https://github.com/jdx/mise-action/pull/481)
+- **(ci)** resolve zizmor findings (#503) by [@jdx](https://github.com/jdx) in [#503](https://github.com/jdx/mise-action/pull/503)
 - include runner image in cache key to prevent cross-provider collisions (#456) by [@jdx](https://github.com/jdx) in [#456](https://github.com/jdx/mise-action/pull/456)
 - install mise-shim.exe on Windows (#476) by [@risu729](https://github.com/risu729) in [#476](https://github.com/jdx/mise-action/pull/476)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mise-action",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mise-action",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "author": "jdx",
   "type": "module",
   "private": true,


### PR DESCRIPTION

---
## [4.2.0](https://github.com/jdx/mise-action/compare/v4.1.0..v4.2.0) - 2026-06-17

### 🚀 Features

- support bootstrap mode (#522) by [@jdx](https://github.com/jdx) in [#522](https://github.com/jdx/mise-action/pull/522)

### 🐛 Bug Fixes

- fall back to wget when curl is unavailable (#521) by [@risu729](https://github.com/risu729) in [#521](https://github.com/jdx/mise-action/pull/521)

### 📚 Documentation

- link rust cache issue (#496) by [@risu729](https://github.com/risu729) in [#496](https://github.com/jdx/mise-action/pull/496)

### ⚙️ Miscellaneous Tasks

- **(ci)** fix zizmor version comments (#506) by [@jdx](https://github.com/jdx) in [#506](https://github.com/jdx/mise-action/pull/506)
- **(ci)** use pr-closer action (#505) by [@jdx](https://github.com/jdx) in [#505](https://github.com/jdx/mise-action/pull/505)

<!-- generated by git-cliff -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release PR with no runtime code changes in the diff.
> 
> **Overview**
> **Release v4.2.0** — bumps `package.json` / `package-lock.json` from **4.1.0** to **4.2.0** and prepends a **4.2.0** section to `CHANGELOG.md` (dated 2026-06-17).
> 
> The new changelog entry documents what ships in this tag: **bootstrap mode** (#522), **wget fallback when curl is missing** (#521), a **Rust cache doc link** (#496), and **CI** tweaks (zizmor version comments, pr-closer). The diff also adds a **4.1.0** bug-fix line for resolving zizmor findings (#503) that was missing from the prior release notes.
> 
> No application or workflow source changes appear in this PR—only version and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2005cfa90ff49d64f7e7d1ce588d6b55d74797cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->