### PR TITLE
chore(ci): fix zizmor version comments

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Install Dependencies
         id: install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       # `.npmrc` pins `node-linker=hoisted` so the layout is
       # npm-flat (rollup's `--configPlugin` resolution
       # requires this).
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           cache: false
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: recursive
           token: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
           persist-credentials: false
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - run: mise run release-plz
         env:
           DRY_RUN: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Release
         run: ./scripts/postversion.sh
@@ -39,7 +39,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Enhance release notes with communique
         run: |
           TAG_NAME="v$(jq -r .version package.json)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - run: aube install
       - run: aubr all
   test: # make sure the action works on a clean machine without building


### PR DESCRIPTION
## Summary
- update hash-pinned action version comments to match the exact tags zizmor resolves
- use `# v6.0.2` for the pinned actions/checkout SHA
- use `# v4.0.1` for the pinned jdx/mise-action SHA

## Tests
- actionlint .github/workflows/*.yml

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only edits on existing action SHAs; no workflow behavior or dependency versions change.
> 
> **Overview**
> Updates inline version comments on hash-pinned **`jdx/mise-action`** steps from `# v4` to **`# v4.0.1`** so they match the tag zizmor expects for the pinned SHA. The change is applied across CI, dist check, test, release, and release-plz workflows; **commit SHAs are unchanged**—only documentation on the pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3791ace611dc01a88cd2cd74b3c90ccbac21d39d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->