### PR TITLE
fix: fall back to wget when curl is unavailable

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 
 npm ci
 npm run all
-git add dist
+git add -f dist

--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ When installing tools hosted on GitHub (like `gh`, `node`, `bun`, etc.), mise ne
 
 **Note:** The action automatically uses `${{ github.token }}` as the default, so in most cases you don't need to explicitly provide it. However, if you encounter rate limit errors, make sure the token is being passed correctly.
 
+## Proxy Configuration
+
+The action downloads mise using Node.js `fetch`, so it does not require `curl`
+or `wget` to be installed in the runner container.
+
+If your runner uses `HTTP_PROXY`, `HTTPS_PROXY`, or `NO_PROXY`, enable Node's
+environment proxy support before the action runs:
+
+```yaml
+env:
+  NODE_USE_ENV_PROXY: "1"
+```
+
 ## Lock Files
 
 If a repo mise lock file such as `mise.lock` is present in the working

--- a/README.md
+++ b/README.md
@@ -116,19 +116,6 @@ When installing tools hosted on GitHub (like `gh`, `node`, `bun`, etc.), mise ne
 
 **Note:** The action automatically uses `${{ github.token }}` as the default, so in most cases you don't need to explicitly provide it. However, if you encounter rate limit errors, make sure the token is being passed correctly.
 
-## Proxy Configuration
-
-The action downloads mise using Node.js `fetch`, so it does not require `curl`
-or `wget` to be installed in the runner container.
-
-If your runner uses `HTTP_PROXY`, `HTTPS_PROXY`, or `NO_PROXY`, enable Node's
-environment proxy support before the action runs:
-
-```yaml
-env:
-  NODE_USE_ENV_PROXY: "1"
-```
-
 ## Lock Files
 
 If a repo mise lock file such as `mise.lock` is present in the working

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,6 +38,7 @@ import require$$1$3 from 'node:console';
 import require$$1$4 from 'node:dns';
 import require$$5$4, { StringDecoder } from 'string_decoder';
 import * as child from 'child_process';
+import { spawn } from 'child_process';
 import { setTimeout as setTimeout$1 } from 'timers';
 import * as stream from 'stream';
 import { Readable } from 'stream';
@@ -49,6 +50,7 @@ import process$1 from 'node:process';
 import https$1 from 'node:https';
 import require$$1$5 from 'tty';
 import fs$1 from 'node:fs';
+import { pipeline } from 'stream/promises';
 
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -89502,10 +89504,10 @@ async function setupMise(version, fetchFromGitHub = false) {
                 break;
             }
             case '.tar.zst':
-                await installFromTarUrl(url, '--zstd -xf -', miseBinPath);
+                await installFromTarUrl(url, ['--zstd', '-xf', '-'], miseBinPath);
                 break;
             case '.tar.gz':
-                await installFromTarUrl(url, '-xzf -', miseBinPath);
+                await installFromTarUrl(url, ['-xzf', '-'], miseBinPath);
                 break;
             default:
                 await downloadToFile(url, miseBinPath);
@@ -89597,10 +89599,6 @@ async function getDownloadTool() {
     info(`Using ${cachedDownloadTool} to download mise`);
     return cachedDownloadTool;
 }
-async function downloadToStdoutShell(url) {
-    const tool = await getDownloadTool();
-    return tool === 'curl' ? `curl -fsSL ${url}` : `wget -qO- ${url}`;
-}
 async function downloadToFile(url, filePath) {
     const tool = await getDownloadTool();
     if (tool === 'curl') {
@@ -89619,13 +89617,44 @@ async function downloadText(url) {
     const rsp = await getExecOutput('wget', ['-qO-', url]);
     return rsp.stdout.trim();
 }
-async function installFromTarUrl(url, tarFlags, miseBinPath) {
+async function installFromTarUrl(url, tarArgs, miseBinPath) {
     const tmpdir = os.tmpdir();
-    const download = await downloadToStdoutShell(url);
-    await exec('sh', [
-        '-c',
-        `${download} | tar ${tarFlags} -C ${tmpdir} && mv ${tmpdir}/mise/bin/mise ${miseBinPath}`
-    ]);
+    const tool = await getDownloadTool();
+    const downloader = spawn(tool, tool === 'curl' ? ['-fsSL', url] : ['-qO-', url], { stdio: ['ignore', 'pipe', 'inherit'] });
+    const tar = spawn('tar', [...tarArgs, '-C', tmpdir], {
+        stdio: ['pipe', 'inherit', 'inherit']
+    });
+    if (!downloader.stdout) {
+        throw new Error(`Failed to start ${tool} download stream`);
+    }
+    const downloadExit = new Promise((resolve, reject) => {
+        downloader.on('error', reject);
+        downloader.on('close', code => {
+            if (code === 0)
+                resolve();
+            else
+                reject(new Error(`${tool} exited with code ${code}`));
+        });
+    });
+    const tarExit = new Promise((resolve, reject) => {
+        tar.on('error', reject);
+        tar.on('close', code => {
+            if (code === 0)
+                resolve();
+            else
+                reject(new Error(`tar exited with code ${code}`));
+        });
+    });
+    try {
+        await pipeline(downloader.stdout, tar.stdin);
+        await Promise.all([downloadExit, tarExit]);
+    }
+    catch (err) {
+        downloader.kill();
+        tar.kill();
+        throw err;
+    }
+    await mv(path$1.join(tmpdir, 'mise', 'bin', 'mise'), miseBinPath);
 }
 async function getInstalledMiseVersion(miseBinPath) {
     const versionOutput = await getExecOutput(miseBinPath, ['version', '--json'], { silent: true });

--- a/dist/index.js
+++ b/dist/index.js
@@ -89654,7 +89654,8 @@ async function installFromTarUrl(url, tarArgs, miseBinPath) {
         tar.kill();
         throw err;
     }
-    await mv(path$1.join(tmpdir, 'mise', 'bin', 'mise'), miseBinPath);
+    const extractedMisePath = path$1.join(tmpdir, 'mise', 'bin', 'mise');
+    await exec('mv', [extractedMisePath, miseBinPath]);
 }
 async function getInstalledMiseVersion(miseBinPath) {
     const versionOutput = await getExecOutput(miseBinPath, ['version', '--json'], { silent: true });

--- a/dist/index.js
+++ b/dist/index.js
@@ -49,7 +49,6 @@ import process$1 from 'node:process';
 import https$1 from 'node:https';
 import require$$1$5 from 'tty';
 import fs$1 from 'node:fs';
-import { pipeline } from 'stream/promises';
 
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -89247,14 +89246,7 @@ const DEFAULT_CACHE_KEY_TEMPLATE = '{{cache_key_prefix}}-{{platform}}{{#if versi
 const ROOT_MISE_LOCK_FILE_PATTERNS = [/^\.?mise(?:\.[^.]+)?\.lock$/];
 const CONFIG_DIR_MISE_LOCK_FILE_PATTERNS = [/^mise(?:\.[^.]+)?\.lock$/];
 const CONFIG_MISE_LOCK_FILE_PATTERNS = [/^config(?:\.[^.]+)?\.lock$/];
-const ACTIVE_PROXY_ENV_VARS = [
-    'HTTP_PROXY',
-    'HTTPS_PROXY',
-    'http_proxy',
-    'https_proxy'
-];
-const FETCH_TIMEOUT_MS = 300_000;
-let warnedFetchProxy = false;
+let cachedDownloadTool;
 async function run() {
     try {
         await setToolVersions();
@@ -89275,8 +89267,8 @@ async function run() {
         // etc.) don't silently send the runner's OIDC token to
         // a third-party cache without explicit consent.
         //
-        // Note: `setupMise` fetches the mise binary itself with Node's
-        // `fetch`, which doesn't go through mise's HTTP layer —
+        // Note: `setupMise` fetches the mise binary itself with
+        // `curl` or `wget`, which doesn't go through mise's HTTP layer —
         // the wings rewriter only kicks in once the resulting
         // mise binary runs `mise install` and friends. Ordering
         // here is irrelevant for binary acceleration; we just
@@ -89504,19 +89496,19 @@ async function setupMise(version, fetchFromGitHub = false) {
             case '.zip': {
                 await withExtractedZip(url, 'mise.zip', async (extractDir) => {
                     const extractedMiseBinDir = path$1.join(extractDir, 'mise', 'bin');
-                    await moveFile(path$1.join(extractedMiseBinDir, 'mise.exe'), miseBinPath);
+                    await mv(path$1.join(extractedMiseBinDir, 'mise.exe'), miseBinPath);
                     await installWindowsMiseShim(extractedMiseBinDir, miseShimPath);
                 });
                 break;
             }
             case '.tar.zst':
-                await installFromTar(url, 'mise.tar.zst', ['--zstd'], miseBinPath);
+                await installFromTarUrl(url, '--zstd -xf -', miseBinPath);
                 break;
             case '.tar.gz':
-                await installFromTar(url, 'mise.tar.gz', ['-z'], miseBinPath);
+                await installFromTarUrl(url, '-xzf -', miseBinPath);
                 break;
             default:
-                await downloadFile(url, miseBinPath);
+                await downloadToFile(url, miseBinPath);
                 await exec('chmod', ['+x', miseBinPath]);
                 break;
         }
@@ -89554,7 +89546,7 @@ async function withExtractedZip(url, archiveName, fn) {
     try {
         const archivePath = path$1.join(tempDir, archiveName);
         const extractDir = path$1.join(tempDir, 'extract');
-        await downloadFile(url, archivePath);
+        await downloadToFile(url, archivePath);
         await exec('unzip', [archivePath, '-d', extractDir]);
         await fn(extractDir);
     }
@@ -89570,7 +89562,7 @@ async function installWindowsMiseShim(extractedMiseBinDir, miseShimPath) {
         info('mise-shim.exe not found in the mise archive; skipping');
         return;
     }
-    await moveFile(extractedMiseShimPath, miseShimPath);
+    await mv(extractedMiseShimPath, miseShimPath);
 }
 async function ensureWindowsMiseShim(miseBinPath, miseShimPath, version) {
     if (process.platform !== 'win32')
@@ -89590,33 +89582,50 @@ async function ensureWindowsMiseShim(miseBinPath, miseShimPath, version) {
         warning(`Failed to install mise-shim.exe: ${errorMessage(err)}. Continuing because mise can fall back to file shim mode on Windows.`);
     }
 }
-async function installFromTar(url, archiveName, tarArgs, miseBinPath) {
-    const tempDir = await fs.promises.mkdtemp(path$1.join(os.tmpdir(), 'mise-action-'));
-    try {
-        const archivePath = path$1.join(tempDir, archiveName);
-        await downloadFile(url, archivePath);
-        await exec('tar', [...tarArgs, '-xf', archivePath, '-C', tempDir]);
-        await moveFile(path$1.join(tempDir, 'mise', 'bin', 'mise'), miseBinPath);
+async function getDownloadTool() {
+    if (cachedDownloadTool)
+        return cachedDownloadTool;
+    if (await which('curl', true)) {
+        cachedDownloadTool = 'curl';
     }
-    finally {
-        await rmRF(tempDir);
+    else if (await which('wget', true)) {
+        cachedDownloadTool = 'wget';
+    }
+    else {
+        throw new Error('Neither curl nor wget is available to download mise');
+    }
+    info(`Using ${cachedDownloadTool} to download mise`);
+    return cachedDownloadTool;
+}
+async function downloadToStdoutShell(url) {
+    const tool = await getDownloadTool();
+    return tool === 'curl' ? `curl -fsSL ${url}` : `wget -qO- ${url}`;
+}
+async function downloadToFile(url, filePath) {
+    const tool = await getDownloadTool();
+    if (tool === 'curl') {
+        await exec('curl', ['-fsSL', url, '--output', filePath]);
+    }
+    else {
+        await exec('wget', ['-qO', filePath, url]);
     }
 }
-async function moveFile(sourcePath, targetPath) {
-    try {
-        await mv(sourcePath, targetPath);
+async function downloadText(url) {
+    const tool = await getDownloadTool();
+    if (tool === 'curl') {
+        const rsp = await getExecOutput('curl', ['-fsSL', url]);
+        return rsp.stdout.trim();
     }
-    catch (err) {
-        if (!isCrossDeviceRename(err))
-            throw err;
-        await fs.promises.copyFile(sourcePath, targetPath);
-        await fs.promises.unlink(sourcePath);
-    }
+    const rsp = await getExecOutput('wget', ['-qO-', url]);
+    return rsp.stdout.trim();
 }
-function isCrossDeviceRename(err) {
-    return (err instanceof Error &&
-        'code' in err &&
-        err.code === 'EXDEV');
+async function installFromTarUrl(url, tarFlags, miseBinPath) {
+    const tmpdir = os.tmpdir();
+    const download = await downloadToStdoutShell(url);
+    await exec('sh', [
+        '-c',
+        `${download} | tar ${tarFlags} -C ${tmpdir} && mv ${tmpdir}/mise/bin/mise ${miseBinPath}`
+    ]);
 }
 async function getInstalledMiseVersion(miseBinPath) {
     const versionOutput = await getExecOutput(miseBinPath, ['version', '--json'], { silent: true });
@@ -89636,50 +89645,7 @@ async function zstdInstalled() {
     }
 }
 async function latestMiseVersion() {
-    return (await fetchText('https://mise.jdx.dev/VERSION')).trim();
-}
-async function fetchText(url) {
-    const rsp = await fetchUrl(url);
-    return await rsp.text();
-}
-async function downloadFile(url, filePath) {
-    const rsp = await fetchUrl(url);
-    if (!rsp.body) {
-        throw new Error(`Failed to download ${url}: empty response body`);
-    }
-    const tempFilePath = path$1.join(path$1.dirname(filePath), `.${path$1.basename(filePath)}.${crypto$1.randomUUID()}.tmp`);
-    try {
-        await pipeline(Readable.fromWeb(rsp.body), fs.createWriteStream(tempFilePath));
-        await moveFile(tempFilePath, filePath);
-    }
-    catch (err) {
-        await fs.promises.rm(tempFilePath, { force: true });
-        throw err;
-    }
-}
-async function fetchUrl(url) {
-    warnIfFetchMayIgnoreProxy();
-    const rsp = await fetch(url, {
-        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
-    });
-    if (!rsp.ok) {
-        throw new Error(`Failed to download ${url}: ${rsp.status} ${rsp.statusText}`);
-    }
-    return rsp;
-}
-function warnIfFetchMayIgnoreProxy() {
-    if (warnedFetchProxy)
-        return;
-    warnedFetchProxy = true;
-    const proxyEnvVar = ACTIVE_PROXY_ENV_VARS.find(name => process.env[name]);
-    if (!proxyEnvVar)
-        return;
-    if (process.env.NODE_USE_ENV_PROXY === '1')
-        return;
-    if (process.execArgv.includes('--use-env-proxy'))
-        return;
-    warning(`${proxyEnvVar} is set, but Node env proxy support is not enabled. ` +
-        'Set NODE_USE_ENV_PROXY=1 at the workflow or job level if mise downloads need to use HTTP_PROXY, HTTPS_PROXY, or NO_PROXY.');
+    return downloadText('https://mise.jdx.dev/VERSION');
 }
 async function setToolVersions() {
     const toolVersions = getInput('tool_versions');

--- a/dist/index.js
+++ b/dist/index.js
@@ -89585,10 +89585,10 @@ async function ensureWindowsMiseShim(miseBinPath, miseShimPath, version) {
 async function getDownloadTool() {
     if (cachedDownloadTool)
         return cachedDownloadTool;
-    if (await which('curl', true)) {
+    if (await which('curl')) {
         cachedDownloadTool = 'curl';
     }
-    else if (await which('wget', true)) {
+    else if (await which('wget')) {
         cachedDownloadTool = 'wget';
     }
     else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -49,6 +49,7 @@ import process$1 from 'node:process';
 import https$1 from 'node:https';
 import require$$1$5 from 'tty';
 import fs$1 from 'node:fs';
+import { pipeline } from 'stream/promises';
 
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -89246,6 +89247,14 @@ const DEFAULT_CACHE_KEY_TEMPLATE = '{{cache_key_prefix}}-{{platform}}{{#if versi
 const ROOT_MISE_LOCK_FILE_PATTERNS = [/^\.?mise(?:\.[^.]+)?\.lock$/];
 const CONFIG_DIR_MISE_LOCK_FILE_PATTERNS = [/^mise(?:\.[^.]+)?\.lock$/];
 const CONFIG_MISE_LOCK_FILE_PATTERNS = [/^config(?:\.[^.]+)?\.lock$/];
+const ACTIVE_PROXY_ENV_VARS = [
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'http_proxy',
+    'https_proxy'
+];
+const FETCH_TIMEOUT_MS = 300_000;
+let warnedFetchProxy = false;
 async function run() {
     try {
         await setToolVersions();
@@ -89266,8 +89275,8 @@ async function run() {
         // etc.) don't silently send the runner's OIDC token to
         // a third-party cache without explicit consent.
         //
-        // Note: `setupMise` fetches the mise binary itself with
-        // `curl`, which doesn't go through mise's HTTP layer —
+        // Note: `setupMise` fetches the mise binary itself with Node's
+        // `fetch`, which doesn't go through mise's HTTP layer —
         // the wings rewriter only kicks in once the resulting
         // mise binary runs `mise install` and friends. Ordering
         // here is irrelevant for binary acceleration; we just
@@ -89495,25 +89504,19 @@ async function setupMise(version, fetchFromGitHub = false) {
             case '.zip': {
                 await withExtractedZip(url, 'mise.zip', async (extractDir) => {
                     const extractedMiseBinDir = path$1.join(extractDir, 'mise', 'bin');
-                    await mv(path$1.join(extractedMiseBinDir, 'mise.exe'), miseBinPath);
+                    await moveFile(path$1.join(extractedMiseBinDir, 'mise.exe'), miseBinPath);
                     await installWindowsMiseShim(extractedMiseBinDir, miseShimPath);
                 });
                 break;
             }
             case '.tar.zst':
-                await exec('sh', [
-                    '-c',
-                    `curl -fsSL ${url} | tar --zstd -xf - -C ${os.tmpdir()} && mv ${os.tmpdir()}/mise/bin/mise ${miseBinPath}`
-                ]);
+                await installFromTar(url, 'mise.tar.zst', ['--zstd'], miseBinPath);
                 break;
             case '.tar.gz':
-                await exec('sh', [
-                    '-c',
-                    `curl -fsSL ${url} | tar -xzf - -C ${os.tmpdir()} && mv ${os.tmpdir()}/mise/bin/mise ${miseBinPath}`
-                ]);
+                await installFromTar(url, 'mise.tar.gz', ['-z'], miseBinPath);
                 break;
             default:
-                await exec('sh', ['-c', `curl -fsSL ${url} > ${miseBinPath}`]);
+                await downloadFile(url, miseBinPath);
                 await exec('chmod', ['+x', miseBinPath]);
                 break;
         }
@@ -89551,7 +89554,7 @@ async function withExtractedZip(url, archiveName, fn) {
     try {
         const archivePath = path$1.join(tempDir, archiveName);
         const extractDir = path$1.join(tempDir, 'extract');
-        await exec('curl', ['-fsSL', url, '--output', archivePath]);
+        await downloadFile(url, archivePath);
         await exec('unzip', [archivePath, '-d', extractDir]);
         await fn(extractDir);
     }
@@ -89567,7 +89570,7 @@ async function installWindowsMiseShim(extractedMiseBinDir, miseShimPath) {
         info('mise-shim.exe not found in the mise archive; skipping');
         return;
     }
-    await mv(extractedMiseShimPath, miseShimPath);
+    await moveFile(extractedMiseShimPath, miseShimPath);
 }
 async function ensureWindowsMiseShim(miseBinPath, miseShimPath, version) {
     if (process.platform !== 'win32')
@@ -89587,6 +89590,34 @@ async function ensureWindowsMiseShim(miseBinPath, miseShimPath, version) {
         warning(`Failed to install mise-shim.exe: ${errorMessage(err)}. Continuing because mise can fall back to file shim mode on Windows.`);
     }
 }
+async function installFromTar(url, archiveName, tarArgs, miseBinPath) {
+    const tempDir = await fs.promises.mkdtemp(path$1.join(os.tmpdir(), 'mise-action-'));
+    try {
+        const archivePath = path$1.join(tempDir, archiveName);
+        await downloadFile(url, archivePath);
+        await exec('tar', [...tarArgs, '-xf', archivePath, '-C', tempDir]);
+        await moveFile(path$1.join(tempDir, 'mise', 'bin', 'mise'), miseBinPath);
+    }
+    finally {
+        await rmRF(tempDir);
+    }
+}
+async function moveFile(sourcePath, targetPath) {
+    try {
+        await mv(sourcePath, targetPath);
+    }
+    catch (err) {
+        if (!isCrossDeviceRename(err))
+            throw err;
+        await fs.promises.copyFile(sourcePath, targetPath);
+        await fs.promises.unlink(sourcePath);
+    }
+}
+function isCrossDeviceRename(err) {
+    return (err instanceof Error &&
+        'code' in err &&
+        err.code === 'EXDEV');
+}
 async function getInstalledMiseVersion(miseBinPath) {
     const versionOutput = await getExecOutput(miseBinPath, ['version', '--json'], { silent: true });
     const versionJson = JSON.parse(versionOutput.stdout);
@@ -89605,11 +89636,50 @@ async function zstdInstalled() {
     }
 }
 async function latestMiseVersion() {
-    const rsp = await getExecOutput('curl', [
-        '-fsSL',
-        'https://mise.jdx.dev/VERSION'
-    ]);
-    return rsp.stdout.trim();
+    return (await fetchText('https://mise.jdx.dev/VERSION')).trim();
+}
+async function fetchText(url) {
+    const rsp = await fetchUrl(url);
+    return await rsp.text();
+}
+async function downloadFile(url, filePath) {
+    const rsp = await fetchUrl(url);
+    if (!rsp.body) {
+        throw new Error(`Failed to download ${url}: empty response body`);
+    }
+    const tempFilePath = path$1.join(path$1.dirname(filePath), `.${path$1.basename(filePath)}.${crypto$1.randomUUID()}.tmp`);
+    try {
+        await pipeline(Readable.fromWeb(rsp.body), fs.createWriteStream(tempFilePath));
+        await moveFile(tempFilePath, filePath);
+    }
+    catch (err) {
+        await fs.promises.rm(tempFilePath, { force: true });
+        throw err;
+    }
+}
+async function fetchUrl(url) {
+    warnIfFetchMayIgnoreProxy();
+    const rsp = await fetch(url, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+    });
+    if (!rsp.ok) {
+        throw new Error(`Failed to download ${url}: ${rsp.status} ${rsp.statusText}`);
+    }
+    return rsp;
+}
+function warnIfFetchMayIgnoreProxy() {
+    if (warnedFetchProxy)
+        return;
+    warnedFetchProxy = true;
+    const proxyEnvVar = ACTIVE_PROXY_ENV_VARS.find(name => process.env[name]);
+    if (!proxyEnvVar)
+        return;
+    if (process.env.NODE_USE_ENV_PROXY === '1')
+        return;
+    if (process.execArgv.includes('--use-env-proxy'))
+        return;
+    warning(`${proxyEnvVar} is set, but Node env proxy support is not enabled. ` +
+        'Set NODE_USE_ENV_PROXY=1 at the workflow or job level if mise downloads need to use HTTP_PROXY, HTTPS_PROXY, or NO_PROXY.');
 }
 async function setToolVersions() {
     const toolVersions = getInput('tool_versions');

--- a/dist/index.js
+++ b/dist/index.js
@@ -89652,6 +89652,8 @@ async function installFromTarUrl(url, tarArgs, miseBinPath) {
     catch (err) {
         downloader.kill();
         tar.kill();
+        downloadExit.catch(() => { });
+        tarExit.catch(() => { });
         throw err;
     }
     const extractedMisePath = path$1.join(tmpdir, 'mise', 'bin', 'mise');

--- a/src/index.ts
+++ b/src/index.ts
@@ -455,9 +455,9 @@ async function ensureWindowsMiseShim(
 
 async function getDownloadTool(): Promise<DownloadTool> {
   if (cachedDownloadTool) return cachedDownloadTool
-  if (await io.which('curl', true)) {
+  if (await io.which('curl')) {
     cachedDownloadTool = 'curl'
-  } else if (await io.which('wget', true)) {
+  } else if (await io.which('wget')) {
     cachedDownloadTool = 'wget'
   } else {
     throw new Error('Neither curl nor wget is available to download mise')

--- a/src/index.ts
+++ b/src/index.ts
@@ -528,6 +528,8 @@ async function installFromTarUrl(
   } catch (err) {
     downloader.kill()
     tar.kill()
+    downloadExit.catch(() => {})
+    tarExit.catch(() => {})
     throw err
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import * as crypto from 'crypto'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
+import { spawn } from 'child_process'
+import { pipeline } from 'stream/promises'
 import * as Handlebars from 'handlebars'
 
 // Configuration file patterns for cache key generation
@@ -344,10 +346,10 @@ async function setupMise(
         break
       }
       case '.tar.zst':
-        await installFromTarUrl(url, '--zstd -xf -', miseBinPath)
+        await installFromTarUrl(url, ['--zstd', '-xf', '-'], miseBinPath)
         break
       case '.tar.gz':
-        await installFromTarUrl(url, '-xzf -', miseBinPath)
+        await installFromTarUrl(url, ['-xzf', '-'], miseBinPath)
         break
       default:
         await downloadToFile(url, miseBinPath)
@@ -466,11 +468,6 @@ async function getDownloadTool(): Promise<DownloadTool> {
   return cachedDownloadTool
 }
 
-async function downloadToStdoutShell(url: string): Promise<string> {
-  const tool = await getDownloadTool()
-  return tool === 'curl' ? `curl -fsSL ${url}` : `wget -qO- ${url}`
-}
-
 async function downloadToFile(url: string, filePath: string): Promise<void> {
   const tool = await getDownloadTool()
   if (tool === 'curl') {
@@ -492,15 +489,49 @@ async function downloadText(url: string): Promise<string> {
 
 async function installFromTarUrl(
   url: string,
-  tarFlags: string,
+  tarArgs: string[],
   miseBinPath: string
 ): Promise<void> {
   const tmpdir = os.tmpdir()
-  const download = await downloadToStdoutShell(url)
-  await exec.exec('sh', [
-    '-c',
-    `${download} | tar ${tarFlags} -C ${tmpdir} && mv ${tmpdir}/mise/bin/mise ${miseBinPath}`
-  ])
+  const tool = await getDownloadTool()
+  const downloader = spawn(
+    tool,
+    tool === 'curl' ? ['-fsSL', url] : ['-qO-', url],
+    { stdio: ['ignore', 'pipe', 'inherit'] }
+  )
+  const tar = spawn('tar', [...tarArgs, '-C', tmpdir], {
+    stdio: ['pipe', 'inherit', 'inherit']
+  })
+
+  if (!downloader.stdout) {
+    throw new Error(`Failed to start ${tool} download stream`)
+  }
+
+  const downloadExit = new Promise<void>((resolve, reject) => {
+    downloader.on('error', reject)
+    downloader.on('close', code => {
+      if (code === 0) resolve()
+      else reject(new Error(`${tool} exited with code ${code}`))
+    })
+  })
+  const tarExit = new Promise<void>((resolve, reject) => {
+    tar.on('error', reject)
+    tar.on('close', code => {
+      if (code === 0) resolve()
+      else reject(new Error(`tar exited with code ${code}`))
+    })
+  })
+
+  try {
+    await pipeline(downloader.stdout, tar.stdin!)
+    await Promise.all([downloadExit, tarExit])
+  } catch (err) {
+    downloader.kill()
+    tar.kill()
+    throw err
+  }
+
+  await io.mv(path.join(tmpdir, 'mise', 'bin', 'mise'), miseBinPath)
 }
 
 async function getInstalledMiseVersion(miseBinPath: string): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -531,7 +531,8 @@ async function installFromTarUrl(
     throw err
   }
 
-  await io.mv(path.join(tmpdir, 'mise', 'bin', 'mise'), miseBinPath)
+  const extractedMisePath = path.join(tmpdir, 'mise', 'bin', 'mise')
+  await exec.exec('mv', [extractedMisePath, miseBinPath])
 }
 
 async function getInstalledMiseVersion(miseBinPath: string): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,6 @@ import * as crypto from 'crypto'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import { Readable } from 'stream'
-import { pipeline } from 'stream/promises'
 import * as Handlebars from 'handlebars'
 
 // Configuration file patterns for cache key generation
@@ -47,14 +45,9 @@ const DEFAULT_CACHE_KEY_TEMPLATE =
 const ROOT_MISE_LOCK_FILE_PATTERNS = [/^\.?mise(?:\.[^.]+)?\.lock$/]
 const CONFIG_DIR_MISE_LOCK_FILE_PATTERNS = [/^mise(?:\.[^.]+)?\.lock$/]
 const CONFIG_MISE_LOCK_FILE_PATTERNS = [/^config(?:\.[^.]+)?\.lock$/]
-const ACTIVE_PROXY_ENV_VARS = [
-  'HTTP_PROXY',
-  'HTTPS_PROXY',
-  'http_proxy',
-  'https_proxy'
-]
-const FETCH_TIMEOUT_MS = 300_000
-let warnedFetchProxy = false
+
+type DownloadTool = 'curl' | 'wget'
+let cachedDownloadTool: DownloadTool | undefined
 
 async function run(): Promise<void> {
   try {
@@ -77,8 +70,8 @@ async function run(): Promise<void> {
     // etc.) don't silently send the runner's OIDC token to
     // a third-party cache without explicit consent.
     //
-    // Note: `setupMise` fetches the mise binary itself with Node's
-    // `fetch`, which doesn't go through mise's HTTP layer —
+    // Note: `setupMise` fetches the mise binary itself with
+    // `curl` or `wget`, which doesn't go through mise's HTTP layer —
     // the wings rewriter only kicks in once the resulting
     // mise binary runs `mise install` and friends. Ordering
     // here is irrelevant for binary acceleration; we just
@@ -345,22 +338,19 @@ async function setupMise(
       case '.zip': {
         await withExtractedZip(url, 'mise.zip', async extractDir => {
           const extractedMiseBinDir = path.join(extractDir, 'mise', 'bin')
-          await moveFile(
-            path.join(extractedMiseBinDir, 'mise.exe'),
-            miseBinPath
-          )
+          await io.mv(path.join(extractedMiseBinDir, 'mise.exe'), miseBinPath)
           await installWindowsMiseShim(extractedMiseBinDir, miseShimPath)
         })
         break
       }
       case '.tar.zst':
-        await installFromTar(url, 'mise.tar.zst', ['--zstd'], miseBinPath)
+        await installFromTarUrl(url, '--zstd -xf -', miseBinPath)
         break
       case '.tar.gz':
-        await installFromTar(url, 'mise.tar.gz', ['-z'], miseBinPath)
+        await installFromTarUrl(url, '-xzf -', miseBinPath)
         break
       default:
-        await downloadFile(url, miseBinPath)
+        await downloadToFile(url, miseBinPath)
         await exec.exec('chmod', ['+x', miseBinPath])
         break
     }
@@ -409,7 +399,7 @@ async function withExtractedZip(
     const archivePath = path.join(tempDir, archiveName)
     const extractDir = path.join(tempDir, 'extract')
 
-    await downloadFile(url, archivePath)
+    await downloadToFile(url, archivePath)
     await exec.exec('unzip', [archivePath, '-d', extractDir])
     await fn(extractDir)
   } finally {
@@ -429,7 +419,7 @@ async function installWindowsMiseShim(
     return
   }
 
-  await moveFile(extractedMiseShimPath, miseShimPath)
+  await io.mv(extractedMiseShimPath, miseShimPath)
 }
 
 async function ensureWindowsMiseShim(
@@ -463,41 +453,54 @@ async function ensureWindowsMiseShim(
   }
 }
 
-async function installFromTar(
+async function getDownloadTool(): Promise<DownloadTool> {
+  if (cachedDownloadTool) return cachedDownloadTool
+  if (await io.which('curl', true)) {
+    cachedDownloadTool = 'curl'
+  } else if (await io.which('wget', true)) {
+    cachedDownloadTool = 'wget'
+  } else {
+    throw new Error('Neither curl nor wget is available to download mise')
+  }
+  core.info(`Using ${cachedDownloadTool} to download mise`)
+  return cachedDownloadTool
+}
+
+async function downloadToStdoutShell(url: string): Promise<string> {
+  const tool = await getDownloadTool()
+  return tool === 'curl' ? `curl -fsSL ${url}` : `wget -qO- ${url}`
+}
+
+async function downloadToFile(url: string, filePath: string): Promise<void> {
+  const tool = await getDownloadTool()
+  if (tool === 'curl') {
+    await exec.exec('curl', ['-fsSL', url, '--output', filePath])
+  } else {
+    await exec.exec('wget', ['-qO', filePath, url])
+  }
+}
+
+async function downloadText(url: string): Promise<string> {
+  const tool = await getDownloadTool()
+  if (tool === 'curl') {
+    const rsp = await exec.getExecOutput('curl', ['-fsSL', url])
+    return rsp.stdout.trim()
+  }
+  const rsp = await exec.getExecOutput('wget', ['-qO-', url])
+  return rsp.stdout.trim()
+}
+
+async function installFromTarUrl(
   url: string,
-  archiveName: string,
-  tarArgs: string[],
+  tarFlags: string,
   miseBinPath: string
 ): Promise<void> {
-  const tempDir = await fs.promises.mkdtemp(
-    path.join(os.tmpdir(), 'mise-action-')
-  )
-  try {
-    const archivePath = path.join(tempDir, archiveName)
-    await downloadFile(url, archivePath)
-    await exec.exec('tar', [...tarArgs, '-xf', archivePath, '-C', tempDir])
-    await moveFile(path.join(tempDir, 'mise', 'bin', 'mise'), miseBinPath)
-  } finally {
-    await io.rmRF(tempDir)
-  }
-}
-
-async function moveFile(sourcePath: string, targetPath: string): Promise<void> {
-  try {
-    await io.mv(sourcePath, targetPath)
-  } catch (err) {
-    if (!isCrossDeviceRename(err)) throw err
-    await fs.promises.copyFile(sourcePath, targetPath)
-    await fs.promises.unlink(sourcePath)
-  }
-}
-
-function isCrossDeviceRename(err: unknown): boolean {
-  return (
-    err instanceof Error &&
-    'code' in err &&
-    (err as NodeJS.ErrnoException).code === 'EXDEV'
-  )
+  const tmpdir = os.tmpdir()
+  const download = await downloadToStdoutShell(url)
+  await exec.exec('sh', [
+    '-c',
+    `${download} | tar ${tarFlags} -C ${tmpdir} && mv ${tmpdir}/mise/bin/mise ${miseBinPath}`
+  ])
 }
 
 async function getInstalledMiseVersion(miseBinPath: string): Promise<string> {
@@ -524,62 +527,7 @@ async function zstdInstalled(): Promise<boolean> {
 }
 
 async function latestMiseVersion(): Promise<string> {
-  return (await fetchText('https://mise.jdx.dev/VERSION')).trim()
-}
-
-async function fetchText(url: string): Promise<string> {
-  const rsp = await fetchUrl(url)
-  return await rsp.text()
-}
-
-async function downloadFile(url: string, filePath: string): Promise<void> {
-  const rsp = await fetchUrl(url)
-  if (!rsp.body) {
-    throw new Error(`Failed to download ${url}: empty response body`)
-  }
-
-  const tempFilePath = path.join(
-    path.dirname(filePath),
-    `.${path.basename(filePath)}.${crypto.randomUUID()}.tmp`
-  )
-  try {
-    await pipeline(
-      Readable.fromWeb(rsp.body),
-      fs.createWriteStream(tempFilePath)
-    )
-    await moveFile(tempFilePath, filePath)
-  } catch (err) {
-    await fs.promises.rm(tempFilePath, { force: true })
-    throw err
-  }
-}
-
-async function fetchUrl(url: string): Promise<Response> {
-  warnIfFetchMayIgnoreProxy()
-  const rsp = await fetch(url, {
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
-  })
-  if (!rsp.ok) {
-    throw new Error(
-      `Failed to download ${url}: ${rsp.status} ${rsp.statusText}`
-    )
-  }
-  return rsp
-}
-
-function warnIfFetchMayIgnoreProxy(): void {
-  if (warnedFetchProxy) return
-  warnedFetchProxy = true
-
-  const proxyEnvVar = ACTIVE_PROXY_ENV_VARS.find(name => process.env[name])
-  if (!proxyEnvVar) return
-  if (process.env.NODE_USE_ENV_PROXY === '1') return
-  if (process.execArgv.includes('--use-env-proxy')) return
-
-  core.warning(
-    `${proxyEnvVar} is set, but Node env proxy support is not enabled. ` +
-      'Set NODE_USE_ENV_PROXY=1 at the workflow or job level if mise downloads need to use HTTP_PROXY, HTTPS_PROXY, or NO_PROXY.'
-  )
+  return downloadText('https://mise.jdx.dev/VERSION')
 }
 
 async function setToolVersions(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import * as crypto from 'crypto'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
+import { Readable } from 'stream'
+import { pipeline } from 'stream/promises'
 import * as Handlebars from 'handlebars'
 
 // Configuration file patterns for cache key generation
@@ -45,6 +47,14 @@ const DEFAULT_CACHE_KEY_TEMPLATE =
 const ROOT_MISE_LOCK_FILE_PATTERNS = [/^\.?mise(?:\.[^.]+)?\.lock$/]
 const CONFIG_DIR_MISE_LOCK_FILE_PATTERNS = [/^mise(?:\.[^.]+)?\.lock$/]
 const CONFIG_MISE_LOCK_FILE_PATTERNS = [/^config(?:\.[^.]+)?\.lock$/]
+const ACTIVE_PROXY_ENV_VARS = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'http_proxy',
+  'https_proxy'
+]
+const FETCH_TIMEOUT_MS = 300_000
+let warnedFetchProxy = false
 
 async function run(): Promise<void> {
   try {
@@ -67,8 +77,8 @@ async function run(): Promise<void> {
     // etc.) don't silently send the runner's OIDC token to
     // a third-party cache without explicit consent.
     //
-    // Note: `setupMise` fetches the mise binary itself with
-    // `curl`, which doesn't go through mise's HTTP layer —
+    // Note: `setupMise` fetches the mise binary itself with Node's
+    // `fetch`, which doesn't go through mise's HTTP layer —
     // the wings rewriter only kicks in once the resulting
     // mise binary runs `mise install` and friends. Ordering
     // here is irrelevant for binary acceleration; we just
@@ -335,25 +345,22 @@ async function setupMise(
       case '.zip': {
         await withExtractedZip(url, 'mise.zip', async extractDir => {
           const extractedMiseBinDir = path.join(extractDir, 'mise', 'bin')
-          await io.mv(path.join(extractedMiseBinDir, 'mise.exe'), miseBinPath)
+          await moveFile(
+            path.join(extractedMiseBinDir, 'mise.exe'),
+            miseBinPath
+          )
           await installWindowsMiseShim(extractedMiseBinDir, miseShimPath)
         })
         break
       }
       case '.tar.zst':
-        await exec.exec('sh', [
-          '-c',
-          `curl -fsSL ${url} | tar --zstd -xf - -C ${os.tmpdir()} && mv ${os.tmpdir()}/mise/bin/mise ${miseBinPath}`
-        ])
+        await installFromTar(url, 'mise.tar.zst', ['--zstd'], miseBinPath)
         break
       case '.tar.gz':
-        await exec.exec('sh', [
-          '-c',
-          `curl -fsSL ${url} | tar -xzf - -C ${os.tmpdir()} && mv ${os.tmpdir()}/mise/bin/mise ${miseBinPath}`
-        ])
+        await installFromTar(url, 'mise.tar.gz', ['-z'], miseBinPath)
         break
       default:
-        await exec.exec('sh', ['-c', `curl -fsSL ${url} > ${miseBinPath}`])
+        await downloadFile(url, miseBinPath)
         await exec.exec('chmod', ['+x', miseBinPath])
         break
     }
@@ -402,7 +409,7 @@ async function withExtractedZip(
     const archivePath = path.join(tempDir, archiveName)
     const extractDir = path.join(tempDir, 'extract')
 
-    await exec.exec('curl', ['-fsSL', url, '--output', archivePath])
+    await downloadFile(url, archivePath)
     await exec.exec('unzip', [archivePath, '-d', extractDir])
     await fn(extractDir)
   } finally {
@@ -422,7 +429,7 @@ async function installWindowsMiseShim(
     return
   }
 
-  await io.mv(extractedMiseShimPath, miseShimPath)
+  await moveFile(extractedMiseShimPath, miseShimPath)
 }
 
 async function ensureWindowsMiseShim(
@@ -456,6 +463,43 @@ async function ensureWindowsMiseShim(
   }
 }
 
+async function installFromTar(
+  url: string,
+  archiveName: string,
+  tarArgs: string[],
+  miseBinPath: string
+): Promise<void> {
+  const tempDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'mise-action-')
+  )
+  try {
+    const archivePath = path.join(tempDir, archiveName)
+    await downloadFile(url, archivePath)
+    await exec.exec('tar', [...tarArgs, '-xf', archivePath, '-C', tempDir])
+    await moveFile(path.join(tempDir, 'mise', 'bin', 'mise'), miseBinPath)
+  } finally {
+    await io.rmRF(tempDir)
+  }
+}
+
+async function moveFile(sourcePath: string, targetPath: string): Promise<void> {
+  try {
+    await io.mv(sourcePath, targetPath)
+  } catch (err) {
+    if (!isCrossDeviceRename(err)) throw err
+    await fs.promises.copyFile(sourcePath, targetPath)
+    await fs.promises.unlink(sourcePath)
+  }
+}
+
+function isCrossDeviceRename(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    'code' in err &&
+    (err as NodeJS.ErrnoException).code === 'EXDEV'
+  )
+}
+
 async function getInstalledMiseVersion(miseBinPath: string): Promise<string> {
   const versionOutput = await exec.getExecOutput(
     miseBinPath,
@@ -480,11 +524,62 @@ async function zstdInstalled(): Promise<boolean> {
 }
 
 async function latestMiseVersion(): Promise<string> {
-  const rsp = await exec.getExecOutput('curl', [
-    '-fsSL',
-    'https://mise.jdx.dev/VERSION'
-  ])
-  return rsp.stdout.trim()
+  return (await fetchText('https://mise.jdx.dev/VERSION')).trim()
+}
+
+async function fetchText(url: string): Promise<string> {
+  const rsp = await fetchUrl(url)
+  return await rsp.text()
+}
+
+async function downloadFile(url: string, filePath: string): Promise<void> {
+  const rsp = await fetchUrl(url)
+  if (!rsp.body) {
+    throw new Error(`Failed to download ${url}: empty response body`)
+  }
+
+  const tempFilePath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${crypto.randomUUID()}.tmp`
+  )
+  try {
+    await pipeline(
+      Readable.fromWeb(rsp.body),
+      fs.createWriteStream(tempFilePath)
+    )
+    await moveFile(tempFilePath, filePath)
+  } catch (err) {
+    await fs.promises.rm(tempFilePath, { force: true })
+    throw err
+  }
+}
+
+async function fetchUrl(url: string): Promise<Response> {
+  warnIfFetchMayIgnoreProxy()
+  const rsp = await fetch(url, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+  })
+  if (!rsp.ok) {
+    throw new Error(
+      `Failed to download ${url}: ${rsp.status} ${rsp.statusText}`
+    )
+  }
+  return rsp
+}
+
+function warnIfFetchMayIgnoreProxy(): void {
+  if (warnedFetchProxy) return
+  warnedFetchProxy = true
+
+  const proxyEnvVar = ACTIVE_PROXY_ENV_VARS.find(name => process.env[name])
+  if (!proxyEnvVar) return
+  if (process.env.NODE_USE_ENV_PROXY === '1') return
+  if (process.execArgv.includes('--use-env-proxy')) return
+
+  core.warning(
+    `${proxyEnvVar} is set, but Node env proxy support is not enabled. ` +
+      'Set NODE_USE_ENV_PROXY=1 at the workflow or job level if mise downloads need to use HTTP_PROXY, HTTPS_PROXY, or NO_PROXY.'
+  )
 }
 
 async function setToolVersions(): Promise<void> {


### PR DESCRIPTION
## Summary

- Prefer `curl` for mise binary downloads and fall back to `wget` when `curl` is not on the runner.
- Keep streaming `curl|tar` / `wget|tar` installs so tar archives are extracted while downloading, preserving the fast path on Linux/macOS.
- Use the same download tool selection for zip archives, standalone binaries, and the `VERSION` lookup.

Proxy support is unchanged: both `curl` and `wget` honor `HTTP_PROXY`, `HTTPS_PROXY`, and related environment variables without extra action configuration.

## Validation

- `aubr all`
- `mise run test`

Addresses jdx/mise#10488.

## Test plan

- [ ] Verify install on a standard GitHub-hosted Ubuntu runner (`curl` present)
- [ ] Verify install on a minimal image with only `wget` installed
- [ ] Confirm `.tar.zst` / `.tar.gz` installs still use a streaming pipe rather than downloading the archive to disk first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved download handling for mise binaries and version retrieval by introducing a cached download abstraction that automatically uses `curl` when available, otherwise falls back to `wget`.
  * Standardized archive download/extract flows for `.tar.gz`/`.tar.zst` and `.zip` to use shared download helpers instead of inline shell commands.

* **Chores**
  * Updated the pre-commit hook to force-add the `dist` directory when staging artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->