### PR TITLE
feat: support bootstrap mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ jobs:
           version: 2026.3.10 # [default: latest] mise version to install
           install: true # [default: true] run `mise install`
           install_args: "bun" # [default: ""] additional arguments to `mise install`
+          bootstrap: false # [default: false] run `mise bootstrap` instead of `mise install`
+          bootstrap_skip: "tools,task" # [default: ""] comma-separated parts to skip when bootstrapping
+          bootstrap_args: "--yes" # [default: ""] additional arguments to `mise bootstrap`
           cache: true # [default: true] cache mise using GitHub's cache
           experimental: true # [default: false] enable experimental features
           log_level: debug # [default: info] log level
@@ -72,6 +75,7 @@ Available template variables:
 - `{{file_hash}}` - Hash of all mise configuration files
 - `{{mise_env}}` - The MISE_ENV environment variable value
 - `{{install_args_hash}}` - SHA256 hash of the sorted tools from install args
+- `{{bootstrap_hash}}` - SHA256 hash of bootstrap mode, skip list, and args
 - `{{default}}` - The processed default cache key (useful for extending)
 
 Conditional logic is also supported using Handlebars syntax like `{{#if version}}...{{/if}}`.
@@ -122,6 +126,21 @@ will be added automatically unless you already included it yourself.
 This auto-detection is intended for repo-managed config files. If you provide
 `mise_toml` or `tool_versions` inputs, the action does not automatically force
 locked mode.
+
+## Bootstrap
+
+Set `bootstrap: true` to run `mise bootstrap` instead of `mise install`:
+
+```yaml
+- uses: jdx/mise-action@v4
+  with:
+    bootstrap: true
+```
+
+When a repo mise lock file is present, the action automatically runs
+`mise --locked bootstrap`. `install_args` cannot be combined with
+`bootstrap: true`; use `bootstrap_skip` and `bootstrap_args` for bootstrap
+customization.
 
 ## Alternative Installation
 

--- a/action.yml
+++ b/action.yml
@@ -26,10 +26,20 @@ inputs:
   install:
     required: false
     default: "true"
-    description: if false, will not run `mise install`
+    description: if false, will not run `mise install` or `mise bootstrap`
   install_args:
     required: false
     description: Arguments to pass to `mise install` such as "bun" to only install bun. When a repo mise lock file is present, the action automatically adds `--locked` unless you already provided it.
+  bootstrap:
+    required: false
+    default: "false"
+    description: if true, will run `mise bootstrap` instead of `mise install`
+  bootstrap_skip:
+    required: false
+    description: Comma-separated bootstrap parts to skip, such as "tools,task". Passed as `mise bootstrap --skip`.
+  bootstrap_args:
+    required: false
+    description: Additional arguments to pass to `mise bootstrap`.
   install_dir:
     required: false
     description: deprecated
@@ -49,8 +59,8 @@ inputs:
     required: false
     description: |
       Override the complete cache key (ignores all other cache key options).
-      Supports template variables: {{version}}, {{cache_key_prefix}}, {{platform}}, {{file_hash}}, 
-      {{mise_env}}, {{install_args_hash}}, {{default}}, {{env.VAR_NAME}} for environment variables, 
+      Supports template variables: {{version}}, {{cache_key_prefix}}, {{platform}}, {{file_hash}},
+      {{mise_env}}, {{install_args_hash}}, {{bootstrap_hash}}, {{default}}, {{env.VAR_NAME}} for environment variables,
       and conditional logic like {{#if version}}...{{/if}}
   experimental:
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -89800,7 +89800,7 @@ async function processCacheKeyTemplate(template) {
     // Get all available variables
     const version = getInput('version');
     const installArgs = getInput('install_args');
-    const bootstrap = getInput('bootstrap');
+    const bootstrap = getBooleanInput('bootstrap');
     const bootstrapSkip = getInput('bootstrap_skip');
     const bootstrapArgs = getInput('bootstrap_args');
     const cacheKeyPrefix = getInput('cache_key_prefix') || 'mise-v1';
@@ -89821,10 +89821,10 @@ async function processCacheKeyTemplate(template) {
         }
     }
     let bootstrapHash = '';
-    if (bootstrap === 'true' || bootstrapSkip || bootstrapArgs) {
+    if (bootstrap) {
         bootstrapHash = crypto$1
             .createHash('sha256')
-            .update([bootstrap, bootstrapSkip, bootstrapArgs].join('\0'))
+            .update([String(bootstrap), bootstrapSkip, bootstrapArgs].join('\0'))
             .digest('hex');
     }
     // Prepare base template data

--- a/dist/index.js
+++ b/dist/index.js
@@ -89821,7 +89821,7 @@ async function processCacheKeyTemplate(template) {
         }
     }
     let bootstrapHash = '';
-    if (bootstrap || bootstrapSkip || bootstrapArgs) {
+    if (bootstrap === 'true' || bootstrapSkip || bootstrapArgs) {
         bootstrapHash = crypto$1
             .createHash('sha256')
             .update([bootstrap, bootstrapSkip, bootstrapArgs].join('\0'))

--- a/dist/index.js
+++ b/dist/index.js
@@ -89646,7 +89646,8 @@ const miseBootstrap = async () => {
     }
     const bootstrapSkip = getInput('bootstrap_skip').trim();
     const bootstrapArgs = getInput('bootstrap_args').trim();
-    const useLocked = await shouldUseLockedInstall();
+    const useLocked = (await shouldUseLockedInstall()) &&
+        !/(^|\s)--locked(?:\s|$)/.test(bootstrapArgs);
     const command = [
         ...(useLocked ? ['--locked'] : []),
         'bootstrap',

--- a/dist/index.js
+++ b/dist/index.js
@@ -89242,7 +89242,7 @@ const MISE_CONFIG_FILE_PATTERNS = [
     `**/.tool-versions`
 ];
 // Default cache key template
-const DEFAULT_CACHE_KEY_TEMPLATE = '{{cache_key_prefix}}-{{platform}}{{#if version}}-{{version}}{{/if}}{{#if mise_env}}-{{mise_env}}{{/if}}{{#if install_args_hash}}-{{install_args_hash}}{{/if}}-{{#if file_hash}}{{file_hash}}{{else}}no-config{{/if}}';
+const DEFAULT_CACHE_KEY_TEMPLATE = '{{cache_key_prefix}}-{{platform}}{{#if version}}-{{version}}{{/if}}{{#if mise_env}}-{{mise_env}}{{/if}}{{#if install_args_hash}}-{{install_args_hash}}{{/if}}{{#if bootstrap_hash}}-{{bootstrap_hash}}{{/if}}-{{#if file_hash}}{{file_hash}}{{else}}no-config{{/if}}';
 const ROOT_MISE_LOCK_FILE_PATTERNS = [/^\.?mise(?:\.[^.]+)?\.lock$/];
 const CONFIG_DIR_MISE_LOCK_FILE_PATTERNS = [/^mise(?:\.[^.]+)?\.lock$/];
 const CONFIG_MISE_LOCK_FILE_PATTERNS = [/^config(?:\.[^.]+)?\.lock$/];
@@ -89284,10 +89284,14 @@ async function run() {
         }
         await testMise();
         if (getBooleanInput('install')) {
-            await miseInstall();
-            if (cacheKey && getBooleanInput('cache_save')) {
-                await saveCache(cacheKey);
+            if (getBooleanInput('bootstrap')) {
+                await miseBootstrap();
             }
+            else {
+                await miseInstall();
+            }
+            if (cacheKey && getBooleanInput('cache_save'))
+                await saveCache(cacheKey);
         }
         await miseLs();
         const loadEnv = getBooleanInput('env');
@@ -89422,8 +89426,10 @@ async function setEnvVars() {
             exportVariable(k, v);
         }
     };
-    if (getBooleanInput('experimental'))
+    if (getBooleanInput('experimental') ||
+        getBooleanInput('bootstrap')) {
         set('MISE_EXPERIMENTAL', '1');
+    }
     const logLevel = getInput('log_level');
     if (logLevel)
         set('MISE_LOG_LEVEL', logLevel);
@@ -89633,6 +89639,25 @@ const miseInstall = async () => {
     }
     return mise([command]);
 };
+const miseBootstrap = async () => {
+    const installArgs = getInput('install_args').trim();
+    if (installArgs) {
+        throw new Error('`install_args` cannot be used when `bootstrap` is true because `mise bootstrap` does not support partial tool install args.');
+    }
+    const bootstrapSkip = getInput('bootstrap_skip').trim();
+    const bootstrapArgs = getInput('bootstrap_args').trim();
+    const useLocked = await shouldUseLockedInstall();
+    const command = [
+        ...(useLocked ? ['--locked'] : []),
+        'bootstrap',
+        ...(bootstrapSkip ? ['--skip', bootstrapSkip] : []),
+        ...(bootstrapArgs ? [bootstrapArgs] : [])
+    ].join(' ');
+    if (useLocked) {
+        info('Detected a mise lock file, running `mise --locked bootstrap`');
+    }
+    return mise([command]);
+};
 const miseLs = async () => mise([`ls`]);
 const miseReshim = async () => mise([`reshim`, `-f`]);
 const mise = async (args) => await group(`Running mise ${args.join(' ')}`, async () => {
@@ -89775,6 +89800,9 @@ async function processCacheKeyTemplate(template) {
     // Get all available variables
     const version = getInput('version');
     const installArgs = getInput('install_args');
+    const bootstrap = getInput('bootstrap');
+    const bootstrapSkip = getInput('bootstrap_skip');
+    const bootstrapArgs = getInput('bootstrap_args');
     const cacheKeyPrefix = getInput('cache_key_prefix') || 'mise-v1';
     const miseEnv = process.env.MISE_ENV?.replace(/,/g, '-');
     const platform = `${await getTarget()}-${getRunnerImageId()}`;
@@ -89792,6 +89820,13 @@ async function processCacheKeyTemplate(template) {
             installArgsHash = crypto$1.createHash('sha256').update(tools).digest('hex');
         }
     }
+    let bootstrapHash = '';
+    if (bootstrap || bootstrapSkip || bootstrapArgs) {
+        bootstrapHash = crypto$1
+            .createHash('sha256')
+            .update([bootstrap, bootstrapSkip, bootstrapArgs].join('\0'))
+            .digest('hex');
+    }
     // Prepare base template data
     const baseTemplateData = {
         version,
@@ -89799,7 +89834,8 @@ async function processCacheKeyTemplate(template) {
         platform,
         file_hash: fileHash,
         mise_env: miseEnv,
-        install_args_hash: installArgsHash
+        install_args_hash: installArgsHash,
+        bootstrap_hash: bootstrapHash
     };
     // Calculate the default cache key by processing the default template
     const defaultTemplate = libExports.compile(DEFAULT_CACHE_KEY_TEMPLATE);

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ const MISE_CONFIG_FILE_PATTERNS = [
 
 // Default cache key template
 const DEFAULT_CACHE_KEY_TEMPLATE =
-  '{{cache_key_prefix}}-{{platform}}{{#if version}}-{{version}}{{/if}}{{#if mise_env}}-{{mise_env}}{{/if}}{{#if install_args_hash}}-{{install_args_hash}}{{/if}}-{{#if file_hash}}{{file_hash}}{{else}}no-config{{/if}}'
+  '{{cache_key_prefix}}-{{platform}}{{#if version}}-{{version}}{{/if}}{{#if mise_env}}-{{mise_env}}{{/if}}{{#if install_args_hash}}-{{install_args_hash}}{{/if}}{{#if bootstrap_hash}}-{{bootstrap_hash}}{{/if}}-{{#if file_hash}}{{file_hash}}{{else}}no-config{{/if}}'
 
 const ROOT_MISE_LOCK_FILE_PATTERNS = [/^\.?mise(?:\.[^.]+)?\.lock$/]
 const CONFIG_DIR_MISE_LOCK_FILE_PATTERNS = [/^mise(?:\.[^.]+)?\.lock$/]
@@ -86,10 +86,13 @@ async function run(): Promise<void> {
     }
     await testMise()
     if (core.getBooleanInput('install')) {
-      await miseInstall()
-      if (cacheKey && core.getBooleanInput('cache_save')) {
-        await saveCache(cacheKey)
+      if (core.getBooleanInput('bootstrap')) {
+        await miseBootstrap()
+      } else {
+        await miseInstall()
       }
+      if (cacheKey && core.getBooleanInput('cache_save'))
+        await saveCache(cacheKey)
     }
     await miseLs()
     const loadEnv = core.getBooleanInput('env')
@@ -243,7 +246,12 @@ async function setEnvVars(): Promise<void> {
       core.exportVariable(k, v)
     }
   }
-  if (core.getBooleanInput('experimental')) set('MISE_EXPERIMENTAL', '1')
+  if (
+    core.getBooleanInput('experimental') ||
+    core.getBooleanInput('bootstrap')
+  ) {
+    set('MISE_EXPERIMENTAL', '1')
+  }
 
   const logLevel = core.getInput('log_level')
   if (logLevel) set('MISE_LOG_LEVEL', logLevel)
@@ -513,6 +521,30 @@ const miseInstall = async (): Promise<number> => {
 
   return mise([command])
 }
+const miseBootstrap = async (): Promise<number> => {
+  const installArgs = core.getInput('install_args').trim()
+  if (installArgs) {
+    throw new Error(
+      '`install_args` cannot be used when `bootstrap` is true because `mise bootstrap` does not support partial tool install args.'
+    )
+  }
+
+  const bootstrapSkip = core.getInput('bootstrap_skip').trim()
+  const bootstrapArgs = core.getInput('bootstrap_args').trim()
+  const useLocked = await shouldUseLockedInstall()
+  const command = [
+    ...(useLocked ? ['--locked'] : []),
+    'bootstrap',
+    ...(bootstrapSkip ? ['--skip', bootstrapSkip] : []),
+    ...(bootstrapArgs ? [bootstrapArgs] : [])
+  ].join(' ')
+
+  if (useLocked) {
+    core.info('Detected a mise lock file, running `mise --locked bootstrap`')
+  }
+
+  return mise([command])
+}
 const miseLs = async (): Promise<number> => mise([`ls`])
 const miseReshim = async (): Promise<number> => mise([`reshim`, `-f`])
 const mise = async (args: string[]): Promise<number> =>
@@ -689,6 +721,9 @@ async function processCacheKeyTemplate(template: string): Promise<string> {
   // Get all available variables
   const version = core.getInput('version')
   const installArgs = core.getInput('install_args')
+  const bootstrap = core.getInput('bootstrap')
+  const bootstrapSkip = core.getInput('bootstrap_skip')
+  const bootstrapArgs = core.getInput('bootstrap_args')
   const cacheKeyPrefix = core.getInput('cache_key_prefix') || 'mise-v1'
   const miseEnv = process.env.MISE_ENV?.replace(/,/g, '-')
   const platform = `${await getTarget()}-${getRunnerImageId()}`
@@ -709,6 +744,14 @@ async function processCacheKeyTemplate(template: string): Promise<string> {
     }
   }
 
+  let bootstrapHash = ''
+  if (bootstrap || bootstrapSkip || bootstrapArgs) {
+    bootstrapHash = crypto
+      .createHash('sha256')
+      .update([bootstrap, bootstrapSkip, bootstrapArgs].join('\0'))
+      .digest('hex')
+  }
+
   // Prepare base template data
   const baseTemplateData = {
     version,
@@ -716,7 +759,8 @@ async function processCacheKeyTemplate(template: string): Promise<string> {
     platform,
     file_hash: fileHash,
     mise_env: miseEnv,
-    install_args_hash: installArgsHash
+    install_args_hash: installArgsHash,
+    bootstrap_hash: bootstrapHash
   }
 
   // Calculate the default cache key by processing the default template

--- a/src/index.ts
+++ b/src/index.ts
@@ -721,7 +721,7 @@ async function processCacheKeyTemplate(template: string): Promise<string> {
   // Get all available variables
   const version = core.getInput('version')
   const installArgs = core.getInput('install_args')
-  const bootstrap = core.getInput('bootstrap')
+  const bootstrap = core.getBooleanInput('bootstrap')
   const bootstrapSkip = core.getInput('bootstrap_skip')
   const bootstrapArgs = core.getInput('bootstrap_args')
   const cacheKeyPrefix = core.getInput('cache_key_prefix') || 'mise-v1'
@@ -745,10 +745,10 @@ async function processCacheKeyTemplate(template: string): Promise<string> {
   }
 
   let bootstrapHash = ''
-  if (bootstrap === 'true' || bootstrapSkip || bootstrapArgs) {
+  if (bootstrap) {
     bootstrapHash = crypto
       .createHash('sha256')
-      .update([bootstrap, bootstrapSkip, bootstrapArgs].join('\0'))
+      .update([String(bootstrap), bootstrapSkip, bootstrapArgs].join('\0'))
       .digest('hex')
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -531,7 +531,9 @@ const miseBootstrap = async (): Promise<number> => {
 
   const bootstrapSkip = core.getInput('bootstrap_skip').trim()
   const bootstrapArgs = core.getInput('bootstrap_args').trim()
-  const useLocked = await shouldUseLockedInstall()
+  const useLocked =
+    (await shouldUseLockedInstall()) &&
+    !/(^|\s)--locked(?:\s|$)/.test(bootstrapArgs)
   const command = [
     ...(useLocked ? ['--locked'] : []),
     'bootstrap',

--- a/src/index.ts
+++ b/src/index.ts
@@ -745,7 +745,7 @@ async function processCacheKeyTemplate(template: string): Promise<string> {
   }
 
   let bootstrapHash = ''
-  if (bootstrap || bootstrapSkip || bootstrapArgs) {
+  if (bootstrap === 'true' || bootstrapSkip || bootstrapArgs) {
     bootstrapHash = crypto
       .createHash('sha256')
       .update([bootstrap, bootstrapSkip, bootstrapArgs].join('\0'))


### PR DESCRIPTION
## Summary
- add `bootstrap`, `bootstrap_skip`, and `bootstrap_args` inputs
- make `bootstrap: true` run `mise bootstrap` instead of `mise install` under the existing `install` gate
- preserve automatic locked mode as `mise --locked bootstrap`
- include bootstrap inputs in the default cache key via `bootstrap_hash`

## Details
`install_args` now fails fast when combined with `bootstrap: true`, because full bootstrap does not support partial tool install args. `bootstrap_skip` relies on `mise bootstrap --skip`, added in jdx/mise#10497.

## Validation
- `aubr all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-facing feature behind an opt-in flag; main behavioral risk is misconfigured bootstrap vs install_args or cache key changes invalidating caches.
> 
> **Overview**
> Adds **`bootstrap`**, **`bootstrap_skip`**, and **`bootstrap_args`** inputs so workflows can run **`mise bootstrap`** instead of **`mise install`** when `install` is enabled.
> 
> When **`bootstrap: true`**, the action runs bootstrap (with optional `--skip` and extra args), sets **`MISE_EXPERIMENTAL=1`**, and **errors if `install_args` is set**. Lock-file detection still applies as **`mise --locked bootstrap`** when appropriate. **Cache save** runs after either install or bootstrap.
> 
> Default and custom cache keys gain **`{{bootstrap_hash}}`** (hash of bootstrap flag, skip list, and args) so bootstrap vs install configs do not share caches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6231de1dc12ef63a9dacc47ee4b3432f35ec0a20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bootstrap support with three new inputs: `bootstrap`, `bootstrap_skip`, and `bootstrap_args`
  * Added `{{bootstrap_hash}}` cache key template variable for distinct caching of bootstrap configurations

* **Documentation**
  * Added Bootstrap section with usage guidance, lock file behavior, and customization details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->