### PR TITLE
chore: release v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 ---
+## [4.2.1](https://github.com/jdx/mise-action/compare/v4.2.0..v4.2.1) - 2026-07-16
+
+### 🐛 Bug Fixes
+
+- verify mise downloads with signed checksums (#548) by [@jdx](https://github.com/jdx) in [#548](https://github.com/jdx/mise-action/pull/548)
+- exclude PATH from environment export (#556) by [@jdx](https://github.com/jdx) in [#556](https://github.com/jdx/mise-action/pull/556)
+
+### 🔍 Other Changes
+
+- Enable Entire for Codex (#529) by [@jdx](https://github.com/jdx) in [#529](https://github.com/jdx/mise-action/pull/529)
+
+### ⚙️ Miscellaneous Tasks
+
+- **(ci)** automate weekly releases (#557) by [@jdx](https://github.com/jdx) in [#557](https://github.com/jdx/mise-action/pull/557)
+- **(release)** skip ai reviews for release prs (#549) by [@jdx](https://github.com/jdx) in [#549](https://github.com/jdx/mise-action/pull/549)
+
+---
 ## [4.2.0](https://github.com/jdx/mise-action/compare/v4.1.0..v4.2.0) - 2026-06-17
 
 ### 🚀 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mise-action",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mise-action",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "author": "jdx",
   "type": "module",
   "private": true,


### PR DESCRIPTION

---
## [4.2.1](https://github.com/jdx/mise-action/compare/v4.2.0..v4.2.1) - 2026-07-16

### 🐛 Bug Fixes

- verify mise downloads with signed checksums (#548) by [@jdx](https://github.com/jdx) in [#548](https://github.com/jdx/mise-action/pull/548)
- exclude PATH from environment export (#556) by [@jdx](https://github.com/jdx) in [#556](https://github.com/jdx/mise-action/pull/556)

### 🔍 Other Changes

- Enable Entire for Codex (#529) by [@jdx](https://github.com/jdx) in [#529](https://github.com/jdx/mise-action/pull/529)

### ⚙️ Miscellaneous Tasks

- **(ci)** automate weekly releases (#557) by [@jdx](https://github.com/jdx) in [#557](https://github.com/jdx/mise-action/pull/557)
- **(release)** skip ai reviews for release prs (#549) by [@jdx](https://github.com/jdx) in [#549](https://github.com/jdx/mise-action/pull/549)

<!-- generated by git-cliff -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release PR with no source or dist changes in the diff.
> 
> **Overview**
> **Release v4.2.1** — bumps the package version from **4.2.0** to **4.2.1** in `package.json` and `package-lock.json`, and prepends a **4.2.1** section to `CHANGELOG.md` (dated 2026-07-16).
> 
> The new changelog section documents what ships in this tag: signed-checksum verification for mise downloads, excluding **PATH** from exported environment variables, Entire-for-Codex enablement, weekly automated releases, and skipping AI reviews on release PRs. This PR does not change action runtime code—only release bookkeeping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e45924cd55ac471e9b021b768d1153bf3a0d55c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->