### PR TITLE
fix: verify mise downloads with signed checksums

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -89309,6 +89309,7 @@ const CONFIG_MISE_LOCK_FILE_PATTERNS = [/^config(?:\.[^.]+)?\.lock$/];
 const MISE_MINISIGN_PUBLIC_KEY = 'RWTC3g8W3z4RZK3V3qv7fa1QY4JEWyBtqIHW+85QlJpZc5yG+uNYNBSZ';
 const MISE_MINISIGN_STARTED_AT = { year: 2024, month: 12, patch: 24 };
 const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
+const verifiedShasums = new Map();
 let cachedDownloadTool;
 async function run() {
     try {
@@ -89550,64 +89551,51 @@ async function setupMise(version, fetchFromGitHub = false) {
         const assetName = `mise-v${resolvedVersion}-${target}${ext}`;
         const rawAssetName = `mise-v${resolvedVersion}-${target}${process.platform === 'win32' ? '.exe' : ''}`;
         const fetchFromCdn = !fetchFromGitHub && !version;
-        const verifyAssetName = fetchFromCdn ? undefined : assetName;
         const githubUrl = `https://github.com/jdx/mise/releases/download/v${resolvedVersion}/${assetName}`;
-        let url;
-        if (fetchFromCdn) {
-            // Only for latest version
-            url = `https://mise.jdx.dev/mise-latest-${target}${ext}`;
-        }
-        else {
-            url = githubUrl;
-        }
+        const cdnUrl = `https://mise.jdx.dev/mise-latest-${target}${process.platform === 'win32' ? '.exe' : ''}`;
         installedVersion = resolvedVersion;
-        const installFromUrl = async (downloadUrl, checksumAssetName) => {
-            let installedBinPath = miseBinPath;
-            let installedShimPath = miseShimPath;
-            await withDownloadedMiseAsset(downloadUrl, resolvedVersion, assetName, checksumAssetName, async (downloadPath, tempDir) => {
-                if (!checksumAssetName) {
-                    const candidateDir = path$1.join(tempDir, 'candidate', 'bin');
-                    await fs.promises.mkdir(candidateDir, { recursive: true });
-                    installedBinPath = path$1.join(candidateDir, process.platform === 'win32' ? 'mise.exe' : 'mise');
-                    installedShimPath = path$1.join(candidateDir, 'mise-shim.exe');
+        const installFromUrl = async (downloadUrl, downloadAssetName, checksumAssetName, extractArchive) => {
+            await withDownloadedMiseAsset(downloadUrl, resolvedVersion, downloadAssetName, checksumAssetName, async (downloadPath, tempDir) => {
+                if (!extractArchive) {
+                    await mv(downloadPath, miseBinPath);
+                    await exec('chmod', ['+x', miseBinPath]);
+                    return;
                 }
                 switch (ext) {
                     case '.zip':
                         await withExtractedZip(downloadPath, tempDir, async (extractDir) => {
                             const extractedMiseBinDir = path$1.join(extractDir, 'mise', 'bin');
-                            await mv(path$1.join(extractedMiseBinDir, 'mise.exe'), installedBinPath);
-                            await installWindowsMiseShim(extractedMiseBinDir, installedShimPath);
+                            await mv(path$1.join(extractedMiseBinDir, 'mise.exe'), miseBinPath);
+                            await installWindowsMiseShim(extractedMiseBinDir, miseShimPath);
                         });
                         break;
                     case '.tar.zst':
-                        await installFromTarFile(downloadPath, ['--zstd', '-xf'], tempDir, installedBinPath);
+                        await installFromTarFile(downloadPath, ['--zstd', '-xf'], tempDir, miseBinPath);
                         break;
                     case '.tar.gz':
-                        await installFromTarFile(downloadPath, ['-xzf'], tempDir, installedBinPath);
+                        await installFromTarFile(downloadPath, ['-xzf'], tempDir, miseBinPath);
                         break;
                     default:
-                        await mv(downloadPath, installedBinPath);
-                        await exec('chmod', ['+x', installedBinPath]);
+                        await mv(downloadPath, miseBinPath);
+                        await exec('chmod', ['+x', miseBinPath]);
                         break;
-                }
-                if (!checksumAssetName) {
-                    await verifyDownloadedMiseAsset(installedBinPath, resolvedVersion, rawAssetName);
-                    await mv(installedBinPath, miseBinPath);
-                    if (fs.existsSync(installedShimPath)) {
-                        await mv(installedShimPath, miseShimPath);
-                    }
                 }
             });
         };
         try {
-            await installFromUrl(url, verifyAssetName);
+            if (fetchFromCdn) {
+                await installFromUrl(cdnUrl, rawAssetName, rawAssetName, false);
+            }
+            else {
+                await installFromUrl(githubUrl, assetName, assetName, true);
+            }
         }
         catch (err) {
             if (!fetchFromCdn) {
                 throw err;
             }
             warning(`Could not verify mise from the CDN: ${errorMessage(err)}. Falling back to the verified GitHub release asset.`);
-            await installFromUrl(githubUrl, assetName);
+            await installFromUrl(githubUrl, assetName, assetName, true);
         }
     }
     else {
@@ -89731,23 +89719,35 @@ async function verifyDownloadedMiseAsset(filePath, version, assetName) {
     if (getInput('sha256')) {
         return;
     }
+    const shasums = await verifiedMiseShasums(version);
+    if (!shasums) {
+        return;
+    }
+    const want = checksumForAsset(shasums, assetName);
+    const got = await sha256File(filePath);
+    if (got !== want) {
+        throw new Error(`SHA256 mismatch: expected ${want}, got ${got} for ${assetName}`);
+    }
+    info(`Verified ${assetName} against signed checksums`);
+}
+async function verifiedMiseShasums(version) {
+    const cached = verifiedShasums.get(version);
+    if (cached) {
+        return cached;
+    }
     try {
         const shasumsUrl = `https://github.com/jdx/mise/releases/download/v${version}/SHASUMS256.txt`;
         const minisigUrl = `${shasumsUrl}.minisig`;
         const shasums = await downloadRawText(shasumsUrl);
         const minisig = await downloadRawText(minisigUrl);
         verifyMinisign(shasums, minisig);
-        const want = checksumForAsset(shasums, assetName);
-        const got = await sha256File(filePath);
-        if (got !== want) {
-            throw new Error(`SHA256 mismatch: expected ${want}, got ${got} for ${assetName}`);
-        }
-        info(`Verified ${assetName} against signed checksums`);
+        verifiedShasums.set(version, shasums);
+        return shasums;
     }
     catch (err) {
         if (miseReleasePredatesMinisign(version)) {
             warning(`Could not verify signed checksums for mise ${version}: ${errorMessage(err)}. Continuing because this pinned version predates mise minisign checksums.`);
-            return;
+            return undefined;
         }
         throw err;
     }
@@ -89769,7 +89769,9 @@ function verifyMinisign(data, minisig) {
     const publicKeyBytes = Buffer.from(MISE_MINISIGN_PUBLIC_KEY, 'base64');
     const signatureBytes = Buffer.from(lines[1], 'base64');
     const trustedSignatureBytes = Buffer.from(lines[3], 'base64');
-    if (publicKeyBytes.length !== 42 || signatureBytes.length !== 74) {
+    if (publicKeyBytes.length !== 42 ||
+        signatureBytes.length !== 74 ||
+        trustedSignatureBytes.length !== 64) {
         throw new Error('Invalid minisign signature format');
     }
     if (!publicKeyBytes.subarray(2, 10).equals(signatureBytes.subarray(2, 10))) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -89562,30 +89562,42 @@ async function setupMise(version, fetchFromGitHub = false) {
         }
         installedVersion = resolvedVersion;
         const installFromUrl = async (downloadUrl, checksumAssetName) => {
+            let installedBinPath = miseBinPath;
+            let installedShimPath = miseShimPath;
             await withDownloadedMiseAsset(downloadUrl, resolvedVersion, assetName, checksumAssetName, async (downloadPath, tempDir) => {
+                if (!checksumAssetName) {
+                    const candidateDir = path$1.join(tempDir, 'candidate', 'bin');
+                    await fs.promises.mkdir(candidateDir, { recursive: true });
+                    installedBinPath = path$1.join(candidateDir, process.platform === 'win32' ? 'mise.exe' : 'mise');
+                    installedShimPath = path$1.join(candidateDir, 'mise-shim.exe');
+                }
                 switch (ext) {
                     case '.zip':
                         await withExtractedZip(downloadPath, tempDir, async (extractDir) => {
                             const extractedMiseBinDir = path$1.join(extractDir, 'mise', 'bin');
-                            await mv(path$1.join(extractedMiseBinDir, 'mise.exe'), miseBinPath);
-                            await installWindowsMiseShim(extractedMiseBinDir, miseShimPath);
+                            await mv(path$1.join(extractedMiseBinDir, 'mise.exe'), installedBinPath);
+                            await installWindowsMiseShim(extractedMiseBinDir, installedShimPath);
                         });
                         break;
                     case '.tar.zst':
-                        await installFromTarFile(downloadPath, ['--zstd', '-xf'], tempDir, miseBinPath);
+                        await installFromTarFile(downloadPath, ['--zstd', '-xf'], tempDir, installedBinPath);
                         break;
                     case '.tar.gz':
-                        await installFromTarFile(downloadPath, ['-xzf'], tempDir, miseBinPath);
+                        await installFromTarFile(downloadPath, ['-xzf'], tempDir, installedBinPath);
                         break;
                     default:
-                        await mv(downloadPath, miseBinPath);
-                        await exec('chmod', ['+x', miseBinPath]);
+                        await mv(downloadPath, installedBinPath);
+                        await exec('chmod', ['+x', installedBinPath]);
                         break;
                 }
+                if (!checksumAssetName) {
+                    await verifyDownloadedMiseAsset(installedBinPath, resolvedVersion, rawAssetName);
+                    await mv(installedBinPath, miseBinPath);
+                    if (fs.existsSync(installedShimPath)) {
+                        await mv(installedShimPath, miseShimPath);
+                    }
+                }
             });
-            if (!checksumAssetName) {
-                await verifyDownloadedMiseAsset(miseBinPath, resolvedVersion, rawAssetName);
-            }
         };
         try {
             await installFromUrl(url, verifyAssetName);

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,7 +38,6 @@ import require$$1$3 from 'node:console';
 import require$$1$4 from 'node:dns';
 import require$$5$4, { StringDecoder } from 'string_decoder';
 import * as child from 'child_process';
-import { spawn } from 'child_process';
 import { setTimeout as setTimeout$1 } from 'timers';
 import * as stream from 'stream';
 import { Readable } from 'stream';
@@ -50,7 +49,6 @@ import process$1 from 'node:process';
 import https$1 from 'node:https';
 import require$$1$5 from 'tty';
 import fs$1 from 'node:fs';
-import { pipeline } from 'stream/promises';
 
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -89308,6 +89306,9 @@ const DEFAULT_CACHE_KEY_TEMPLATE = '{{cache_key_prefix}}-{{platform}}{{#if versi
 const ROOT_MISE_LOCK_FILE_PATTERNS = [/^\.?mise(?:\.[^.]+)?\.lock$/];
 const CONFIG_DIR_MISE_LOCK_FILE_PATTERNS = [/^mise(?:\.[^.]+)?\.lock$/];
 const CONFIG_MISE_LOCK_FILE_PATTERNS = [/^config(?:\.[^.]+)?\.lock$/];
+const MISE_MINISIGN_PUBLIC_KEY = 'RWTC3g8W3z4RZK3V3qv7fa1QY4JEWyBtqIHW+85QlJpZc5yG+uNYNBSZ';
+const MISE_MINISIGN_STARTED_AT = { year: 2024, month: 12, patch: 24 };
+const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
 let cachedDownloadTool;
 async function run() {
     try {
@@ -89545,34 +89546,56 @@ async function setupMise(version, fetchFromGitHub = false) {
                     : '.tar.gz';
         let resolvedVersion = version || (await latestMiseVersion());
         resolvedVersion = resolvedVersion.replace(/^v/, '');
+        const target = await getTarget();
+        const assetName = `mise-v${resolvedVersion}-${target}${ext}`;
+        const rawAssetName = `mise-v${resolvedVersion}-${target}${process.platform === 'win32' ? '.exe' : ''}`;
+        const fetchFromCdn = !fetchFromGitHub && !version;
+        const verifyAssetName = fetchFromCdn ? undefined : assetName;
+        const githubUrl = `https://github.com/jdx/mise/releases/download/v${resolvedVersion}/${assetName}`;
         let url;
-        if (!fetchFromGitHub && !version) {
+        if (fetchFromCdn) {
             // Only for latest version
-            url = `https://mise.jdx.dev/mise-latest-${await getTarget()}${ext}`;
+            url = `https://mise.jdx.dev/mise-latest-${target}${ext}`;
         }
         else {
-            url = `https://github.com/jdx/mise/releases/download/v${resolvedVersion}/mise-v${resolvedVersion}-${await getTarget()}${ext}`;
+            url = githubUrl;
         }
         installedVersion = resolvedVersion;
-        switch (ext) {
-            case '.zip': {
-                await withExtractedZip(url, 'mise.zip', async (extractDir) => {
-                    const extractedMiseBinDir = path$1.join(extractDir, 'mise', 'bin');
-                    await mv(path$1.join(extractedMiseBinDir, 'mise.exe'), miseBinPath);
-                    await installWindowsMiseShim(extractedMiseBinDir, miseShimPath);
-                });
-                break;
+        const installFromUrl = async (downloadUrl, checksumAssetName) => {
+            await withDownloadedMiseAsset(downloadUrl, resolvedVersion, assetName, checksumAssetName, async (downloadPath, tempDir) => {
+                switch (ext) {
+                    case '.zip':
+                        await withExtractedZip(downloadPath, tempDir, async (extractDir) => {
+                            const extractedMiseBinDir = path$1.join(extractDir, 'mise', 'bin');
+                            await mv(path$1.join(extractedMiseBinDir, 'mise.exe'), miseBinPath);
+                            await installWindowsMiseShim(extractedMiseBinDir, miseShimPath);
+                        });
+                        break;
+                    case '.tar.zst':
+                        await installFromTarFile(downloadPath, ['--zstd', '-xf'], tempDir, miseBinPath);
+                        break;
+                    case '.tar.gz':
+                        await installFromTarFile(downloadPath, ['-xzf'], tempDir, miseBinPath);
+                        break;
+                    default:
+                        await mv(downloadPath, miseBinPath);
+                        await exec('chmod', ['+x', miseBinPath]);
+                        break;
+                }
+            });
+            if (!checksumAssetName) {
+                await verifyDownloadedMiseAsset(miseBinPath, resolvedVersion, rawAssetName);
             }
-            case '.tar.zst':
-                await installFromTarUrl(url, ['--zstd', '-xf', '-'], miseBinPath);
-                break;
-            case '.tar.gz':
-                await installFromTarUrl(url, ['-xzf', '-'], miseBinPath);
-                break;
-            default:
-                await downloadToFile(url, miseBinPath);
-                await exec('chmod', ['+x', miseBinPath]);
-                break;
+        };
+        try {
+            await installFromUrl(url, verifyAssetName);
+        }
+        catch (err) {
+            if (!fetchFromCdn) {
+                throw err;
+            }
+            warning(`Could not verify mise from the CDN: ${errorMessage(err)}. Falling back to the verified GitHub release asset.`);
+            await installFromUrl(githubUrl, assetName);
         }
     }
     else {
@@ -89603,18 +89626,10 @@ async function setupMise(version, fetchFromGitHub = false) {
     }
     addPath(miseBinDir);
 }
-async function withExtractedZip(url, archiveName, fn) {
-    const tempDir = await fs.promises.mkdtemp(path$1.join(os.tmpdir(), 'mise-action-'));
-    try {
-        const archivePath = path$1.join(tempDir, archiveName);
-        const extractDir = path$1.join(tempDir, 'extract');
-        await downloadToFile(url, archivePath);
-        await exec('unzip', [archivePath, '-d', extractDir]);
-        await fn(extractDir);
-    }
-    finally {
-        await rmRF(tempDir);
-    }
+async function withExtractedZip(archivePath, tempDir, fn) {
+    const extractDir = path$1.join(tempDir, 'extract');
+    await exec('unzip', [archivePath, '-d', extractDir]);
+    await fn(extractDir);
 }
 async function installWindowsMiseShim(extractedMiseBinDir, miseShimPath) {
     if (process.platform !== 'win32')
@@ -89636,8 +89651,10 @@ async function ensureWindowsMiseShim(miseBinPath, miseShimPath, version) {
         const installedVersion = version || (await getInstalledMiseVersion(miseBinPath));
         const archiveName = `mise-v${installedVersion}-${await getTarget()}.zip`;
         const url = `https://github.com/jdx/mise/releases/download/v${installedVersion}/${archiveName}`;
-        await withExtractedZip(url, archiveName, async (extractDir) => {
-            await installWindowsMiseShim(path$1.join(extractDir, 'mise', 'bin'), miseShimPath);
+        await withDownloadedMiseAsset(url, installedVersion, archiveName, archiveName, async (downloadPath, tempDir) => {
+            await withExtractedZip(downloadPath, tempDir, async (extractDir) => {
+                await installWindowsMiseShim(path$1.join(extractDir, 'mise', 'bin'), miseShimPath);
+            });
         });
     }
     catch (err) {
@@ -89669,54 +89686,124 @@ async function downloadToFile(url, filePath) {
     }
 }
 async function downloadText(url) {
+    return (await downloadRawText(url)).trim();
+}
+async function downloadRawText(url) {
     const tool = await getDownloadTool();
     if (tool === 'curl') {
-        const rsp = await getExecOutput('curl', ['-fsSL', url]);
-        return rsp.stdout.trim();
+        const rsp = await getExecOutput('curl', ['-fsSL', url], {
+            silent: true
+        });
+        return rsp.stdout;
     }
-    const rsp = await getExecOutput('wget', ['-qO-', url]);
-    return rsp.stdout.trim();
+    const rsp = await getExecOutput('wget', ['-qO-', url], {
+        silent: true
+    });
+    return rsp.stdout;
 }
-async function installFromTarUrl(url, tarArgs, miseBinPath) {
-    const tmpdir = os.tmpdir();
-    const tool = await getDownloadTool();
-    const downloader = spawn(tool, tool === 'curl' ? ['-fsSL', url] : ['-qO-', url], { stdio: ['ignore', 'pipe', 'inherit'] });
-    const tar = spawn('tar', [...tarArgs, '-C', tmpdir], {
-        stdio: ['pipe', 'inherit', 'inherit']
-    });
-    if (!downloader.stdout) {
-        throw new Error(`Failed to start ${tool} download stream`);
-    }
-    const downloadExit = new Promise((resolve, reject) => {
-        downloader.on('error', reject);
-        downloader.on('close', code => {
-            if (code === 0)
-                resolve();
-            else
-                reject(new Error(`${tool} exited with code ${code}`));
-        });
-    });
-    const tarExit = new Promise((resolve, reject) => {
-        tar.on('error', reject);
-        tar.on('close', code => {
-            if (code === 0)
-                resolve();
-            else
-                reject(new Error(`tar exited with code ${code}`));
-        });
-    });
+async function withDownloadedMiseAsset(url, version, assetName, verifyAssetName, fn) {
+    const tempDir = await fs.promises.mkdtemp(path$1.join(os.tmpdir(), 'mise-action-'));
     try {
-        await pipeline(downloader.stdout, tar.stdin);
-        await Promise.all([downloadExit, tarExit]);
+        const downloadPath = path$1.join(tempDir, assetName);
+        await downloadToFile(url, downloadPath);
+        if (verifyAssetName) {
+            await verifyDownloadedMiseAsset(downloadPath, version, verifyAssetName);
+        }
+        await fn(downloadPath, tempDir);
+    }
+    finally {
+        await rmRF(tempDir);
+    }
+}
+async function verifyDownloadedMiseAsset(filePath, version, assetName) {
+    if (getInput('sha256')) {
+        return;
+    }
+    try {
+        const shasumsUrl = `https://github.com/jdx/mise/releases/download/v${version}/SHASUMS256.txt`;
+        const minisigUrl = `${shasumsUrl}.minisig`;
+        const shasums = await downloadRawText(shasumsUrl);
+        const minisig = await downloadRawText(minisigUrl);
+        verifyMinisign(shasums, minisig);
+        const want = checksumForAsset(shasums, assetName);
+        const got = await sha256File(filePath);
+        if (got !== want) {
+            throw new Error(`SHA256 mismatch: expected ${want}, got ${got} for ${assetName}`);
+        }
+        info(`Verified ${assetName} against signed checksums`);
     }
     catch (err) {
-        downloader.kill();
-        tar.kill();
-        downloadExit.catch(() => { });
-        tarExit.catch(() => { });
+        if (miseReleasePredatesMinisign(version)) {
+            warning(`Could not verify signed checksums for mise ${version}: ${errorMessage(err)}. Continuing because this pinned version predates mise minisign checksums.`);
+            return;
+        }
         throw err;
     }
-    const extractedMisePath = path$1.join(tmpdir, 'mise', 'bin', 'mise');
+}
+function checksumForAsset(shasums, assetName) {
+    for (const line of shasums.split(/\r?\n/)) {
+        const match = line.match(/^([a-fA-F0-9]{64})\s+\*?(.+)$/);
+        if (match && path$1.basename(match[2]) === assetName) {
+            return match[1].toLowerCase();
+        }
+    }
+    throw new Error(`No checksum found for ${assetName}`);
+}
+function verifyMinisign(data, minisig) {
+    const lines = minisig.trimEnd().split(/\r?\n/);
+    if (lines.length < 4) {
+        throw new Error('Invalid minisign signature');
+    }
+    const publicKeyBytes = Buffer.from(MISE_MINISIGN_PUBLIC_KEY, 'base64');
+    const signatureBytes = Buffer.from(lines[1], 'base64');
+    const trustedSignatureBytes = Buffer.from(lines[3], 'base64');
+    if (publicKeyBytes.length !== 42 || signatureBytes.length !== 74) {
+        throw new Error('Invalid minisign signature format');
+    }
+    if (!publicKeyBytes.subarray(2, 10).equals(signatureBytes.subarray(2, 10))) {
+        throw new Error('Minisign key id mismatch');
+    }
+    const publicKey = crypto$1.createPublicKey({
+        key: Buffer.concat([ED25519_SPKI_PREFIX, publicKeyBytes.subarray(10)]),
+        format: 'der',
+        type: 'spki'
+    });
+    const dataDigest = crypto$1.createHash('blake2b512').update(data).digest();
+    const dataSignature = signatureBytes.subarray(10);
+    if (!crypto$1.verify(null, dataDigest, publicKey, dataSignature)) {
+        throw new Error('Invalid SHASUMS256.txt minisign signature');
+    }
+    const trustedComment = lines[2].replace(/^trusted comment: /, '');
+    const trustedCommentData = Buffer.concat([
+        dataSignature,
+        Buffer.from(trustedComment)
+    ]);
+    if (!crypto$1.verify(null, trustedCommentData, publicKey, trustedSignatureBytes)) {
+        throw new Error('Invalid minisign trusted comment signature');
+    }
+}
+function miseReleasePredatesMinisign(version) {
+    const match = cleanVersion(version).match(/^(\d{4})\.(\d{1,2})\.(\d{1,2})/);
+    if (!match) {
+        return false;
+    }
+    const [, year, month, patch] = match.map(Number);
+    if (year !== MISE_MINISIGN_STARTED_AT.year) {
+        return year < MISE_MINISIGN_STARTED_AT.year;
+    }
+    if (month !== MISE_MINISIGN_STARTED_AT.month) {
+        return month < MISE_MINISIGN_STARTED_AT.month;
+    }
+    return patch < MISE_MINISIGN_STARTED_AT.patch;
+}
+async function sha256File(filePath) {
+    const hash = crypto$1.createHash('sha256');
+    const fileBuffer = await fs.promises.readFile(filePath);
+    return hash.update(fileBuffer).digest('hex');
+}
+async function installFromTarFile(archivePath, tarArgs, tempDir, miseBinPath) {
+    await exec('tar', [...tarArgs, archivePath, '-C', tempDir]);
+    const extractedMisePath = path$1.join(tempDir, 'mise', 'bin', 'mise');
     await exec('mv', [extractedMisePath, miseBinPath]);
 }
 async function getInstalledMiseVersion(miseBinPath) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,6 @@ import * as crypto from 'crypto'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import { spawn } from 'child_process'
-import { pipeline } from 'stream/promises'
 import * as Handlebars from 'handlebars'
 
 // Configuration file patterns for cache key generation
@@ -47,6 +45,10 @@ const DEFAULT_CACHE_KEY_TEMPLATE =
 const ROOT_MISE_LOCK_FILE_PATTERNS = [/^\.?mise(?:\.[^.]+)?\.lock$/]
 const CONFIG_DIR_MISE_LOCK_FILE_PATTERNS = [/^mise(?:\.[^.]+)?\.lock$/]
 const CONFIG_MISE_LOCK_FILE_PATTERNS = [/^config(?:\.[^.]+)?\.lock$/]
+const MISE_MINISIGN_PUBLIC_KEY =
+  'RWTC3g8W3z4RZK3V3qv7fa1QY4JEWyBtqIHW+85QlJpZc5yG+uNYNBSZ'
+const MISE_MINISIGN_STARTED_AT = { year: 2024, month: 12, patch: 24 }
+const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex')
 
 type DownloadTool = 'curl' | 'wget'
 let cachedDownloadTool: DownloadTool | undefined
@@ -328,33 +330,95 @@ async function setupMise(
             : '.tar.gz'
     let resolvedVersion = version || (await latestMiseVersion())
     resolvedVersion = resolvedVersion.replace(/^v/, '')
+    const target = await getTarget()
+    const assetName = `mise-v${resolvedVersion}-${target}${ext}`
+    const rawAssetName = `mise-v${resolvedVersion}-${target}${
+      process.platform === 'win32' ? '.exe' : ''
+    }`
+    const fetchFromCdn = !fetchFromGitHub && !version
+    const verifyAssetName = fetchFromCdn ? undefined : assetName
+    const githubUrl = `https://github.com/jdx/mise/releases/download/v${resolvedVersion}/${assetName}`
     let url: string
-    if (!fetchFromGitHub && !version) {
+    if (fetchFromCdn) {
       // Only for latest version
-      url = `https://mise.jdx.dev/mise-latest-${await getTarget()}${ext}`
+      url = `https://mise.jdx.dev/mise-latest-${target}${ext}`
     } else {
-      url = `https://github.com/jdx/mise/releases/download/v${resolvedVersion}/mise-v${resolvedVersion}-${await getTarget()}${ext}`
+      url = githubUrl
     }
     installedVersion = resolvedVersion
-    switch (ext) {
-      case '.zip': {
-        await withExtractedZip(url, 'mise.zip', async extractDir => {
-          const extractedMiseBinDir = path.join(extractDir, 'mise', 'bin')
-          await io.mv(path.join(extractedMiseBinDir, 'mise.exe'), miseBinPath)
-          await installWindowsMiseShim(extractedMiseBinDir, miseShimPath)
-        })
-        break
+    const installFromUrl = async (
+      downloadUrl: string,
+      checksumAssetName: string | undefined
+    ): Promise<void> => {
+      await withDownloadedMiseAsset(
+        downloadUrl,
+        resolvedVersion,
+        assetName,
+        checksumAssetName,
+        async (downloadPath, tempDir) => {
+          switch (ext) {
+            case '.zip':
+              await withExtractedZip(
+                downloadPath,
+                tempDir,
+                async extractDir => {
+                  const extractedMiseBinDir = path.join(
+                    extractDir,
+                    'mise',
+                    'bin'
+                  )
+                  await io.mv(
+                    path.join(extractedMiseBinDir, 'mise.exe'),
+                    miseBinPath
+                  )
+                  await installWindowsMiseShim(
+                    extractedMiseBinDir,
+                    miseShimPath
+                  )
+                }
+              )
+              break
+            case '.tar.zst':
+              await installFromTarFile(
+                downloadPath,
+                ['--zstd', '-xf'],
+                tempDir,
+                miseBinPath
+              )
+              break
+            case '.tar.gz':
+              await installFromTarFile(
+                downloadPath,
+                ['-xzf'],
+                tempDir,
+                miseBinPath
+              )
+              break
+            default:
+              await io.mv(downloadPath, miseBinPath)
+              await exec.exec('chmod', ['+x', miseBinPath])
+              break
+          }
+        }
+      )
+      if (!checksumAssetName) {
+        await verifyDownloadedMiseAsset(
+          miseBinPath,
+          resolvedVersion,
+          rawAssetName
+        )
       }
-      case '.tar.zst':
-        await installFromTarUrl(url, ['--zstd', '-xf', '-'], miseBinPath)
-        break
-      case '.tar.gz':
-        await installFromTarUrl(url, ['-xzf', '-'], miseBinPath)
-        break
-      default:
-        await downloadToFile(url, miseBinPath)
-        await exec.exec('chmod', ['+x', miseBinPath])
-        break
+    }
+    try {
+      await installFromUrl(url, verifyAssetName)
+    } catch (err) {
+      if (!fetchFromCdn) {
+        throw err
+      }
+      core.warning(
+        `Could not verify mise from the CDN: ${errorMessage(err)}. Falling back to the verified GitHub release asset.`
+      )
+      await installFromUrl(githubUrl, assetName)
     }
   } else {
     const requestedVersion = cleanVersion(core.getInput('version'))
@@ -390,23 +454,13 @@ async function setupMise(
 }
 
 async function withExtractedZip(
-  url: string,
-  archiveName: string,
+  archivePath: string,
+  tempDir: string,
   fn: (extractDir: string) => Promise<void>
 ): Promise<void> {
-  const tempDir = await fs.promises.mkdtemp(
-    path.join(os.tmpdir(), 'mise-action-')
-  )
-  try {
-    const archivePath = path.join(tempDir, archiveName)
-    const extractDir = path.join(tempDir, 'extract')
-
-    await downloadToFile(url, archivePath)
-    await exec.exec('unzip', [archivePath, '-d', extractDir])
-    await fn(extractDir)
-  } finally {
-    await io.rmRF(tempDir)
-  }
+  const extractDir = path.join(tempDir, 'extract')
+  await exec.exec('unzip', [archivePath, '-d', extractDir])
+  await fn(extractDir)
 }
 
 async function installWindowsMiseShim(
@@ -442,12 +496,20 @@ async function ensureWindowsMiseShim(
     const archiveName = `mise-v${installedVersion}-${await getTarget()}.zip`
     const url = `https://github.com/jdx/mise/releases/download/v${installedVersion}/${archiveName}`
 
-    await withExtractedZip(url, archiveName, async extractDir => {
-      await installWindowsMiseShim(
-        path.join(extractDir, 'mise', 'bin'),
-        miseShimPath
-      )
-    })
+    await withDownloadedMiseAsset(
+      url,
+      installedVersion,
+      archiveName,
+      archiveName,
+      async (downloadPath, tempDir) => {
+        await withExtractedZip(downloadPath, tempDir, async extractDir => {
+          await installWindowsMiseShim(
+            path.join(extractDir, 'mise', 'bin'),
+            miseShimPath
+          )
+        })
+      }
+    )
   } catch (err) {
     core.warning(
       `Failed to install mise-shim.exe: ${errorMessage(err)}. Continuing because mise can fall back to file shim mode on Windows.`
@@ -478,62 +540,157 @@ async function downloadToFile(url: string, filePath: string): Promise<void> {
 }
 
 async function downloadText(url: string): Promise<string> {
-  const tool = await getDownloadTool()
-  if (tool === 'curl') {
-    const rsp = await exec.getExecOutput('curl', ['-fsSL', url])
-    return rsp.stdout.trim()
-  }
-  const rsp = await exec.getExecOutput('wget', ['-qO-', url])
-  return rsp.stdout.trim()
+  return (await downloadRawText(url)).trim()
 }
 
-async function installFromTarUrl(
-  url: string,
-  tarArgs: string[],
-  miseBinPath: string
-): Promise<void> {
-  const tmpdir = os.tmpdir()
+async function downloadRawText(url: string): Promise<string> {
   const tool = await getDownloadTool()
-  const downloader = spawn(
-    tool,
-    tool === 'curl' ? ['-fsSL', url] : ['-qO-', url],
-    { stdio: ['ignore', 'pipe', 'inherit'] }
-  )
-  const tar = spawn('tar', [...tarArgs, '-C', tmpdir], {
-    stdio: ['pipe', 'inherit', 'inherit']
-  })
-
-  if (!downloader.stdout) {
-    throw new Error(`Failed to start ${tool} download stream`)
+  if (tool === 'curl') {
+    const rsp = await exec.getExecOutput('curl', ['-fsSL', url], {
+      silent: true
+    })
+    return rsp.stdout
   }
+  const rsp = await exec.getExecOutput('wget', ['-qO-', url], {
+    silent: true
+  })
+  return rsp.stdout
+}
 
-  const downloadExit = new Promise<void>((resolve, reject) => {
-    downloader.on('error', reject)
-    downloader.on('close', code => {
-      if (code === 0) resolve()
-      else reject(new Error(`${tool} exited with code ${code}`))
-    })
-  })
-  const tarExit = new Promise<void>((resolve, reject) => {
-    tar.on('error', reject)
-    tar.on('close', code => {
-      if (code === 0) resolve()
-      else reject(new Error(`tar exited with code ${code}`))
-    })
-  })
+async function withDownloadedMiseAsset(
+  url: string,
+  version: string,
+  assetName: string,
+  verifyAssetName: string | undefined,
+  fn: (downloadPath: string, tempDir: string) => Promise<void>
+): Promise<void> {
+  const tempDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'mise-action-')
+  )
+  try {
+    const downloadPath = path.join(tempDir, assetName)
+    await downloadToFile(url, downloadPath)
+    if (verifyAssetName) {
+      await verifyDownloadedMiseAsset(downloadPath, version, verifyAssetName)
+    }
+    await fn(downloadPath, tempDir)
+  } finally {
+    await io.rmRF(tempDir)
+  }
+}
+
+async function verifyDownloadedMiseAsset(
+  filePath: string,
+  version: string,
+  assetName: string
+): Promise<void> {
+  if (core.getInput('sha256')) {
+    return
+  }
 
   try {
-    await pipeline(downloader.stdout, tar.stdin!)
-    await Promise.all([downloadExit, tarExit])
+    const shasumsUrl = `https://github.com/jdx/mise/releases/download/v${version}/SHASUMS256.txt`
+    const minisigUrl = `${shasumsUrl}.minisig`
+    const shasums = await downloadRawText(shasumsUrl)
+    const minisig = await downloadRawText(minisigUrl)
+    verifyMinisign(shasums, minisig)
+    const want = checksumForAsset(shasums, assetName)
+    const got = await sha256File(filePath)
+    if (got !== want) {
+      throw new Error(
+        `SHA256 mismatch: expected ${want}, got ${got} for ${assetName}`
+      )
+    }
+    core.info(`Verified ${assetName} against signed checksums`)
   } catch (err) {
-    downloader.kill()
-    tar.kill()
-    downloadExit.catch(() => {})
-    tarExit.catch(() => {})
+    if (miseReleasePredatesMinisign(version)) {
+      core.warning(
+        `Could not verify signed checksums for mise ${version}: ${errorMessage(err)}. Continuing because this pinned version predates mise minisign checksums.`
+      )
+      return
+    }
     throw err
   }
+}
 
-  const extractedMisePath = path.join(tmpdir, 'mise', 'bin', 'mise')
+function checksumForAsset(shasums: string, assetName: string): string {
+  for (const line of shasums.split(/\r?\n/)) {
+    const match = line.match(/^([a-fA-F0-9]{64})\s+\*?(.+)$/)
+    if (match && path.basename(match[2]) === assetName) {
+      return match[1].toLowerCase()
+    }
+  }
+  throw new Error(`No checksum found for ${assetName}`)
+}
+
+function verifyMinisign(data: string, minisig: string): void {
+  const lines = minisig.trimEnd().split(/\r?\n/)
+  if (lines.length < 4) {
+    throw new Error('Invalid minisign signature')
+  }
+
+  const publicKeyBytes = Buffer.from(MISE_MINISIGN_PUBLIC_KEY, 'base64')
+  const signatureBytes = Buffer.from(lines[1], 'base64')
+  const trustedSignatureBytes = Buffer.from(lines[3], 'base64')
+  if (publicKeyBytes.length !== 42 || signatureBytes.length !== 74) {
+    throw new Error('Invalid minisign signature format')
+  }
+  if (!publicKeyBytes.subarray(2, 10).equals(signatureBytes.subarray(2, 10))) {
+    throw new Error('Minisign key id mismatch')
+  }
+
+  const publicKey = crypto.createPublicKey({
+    key: Buffer.concat([ED25519_SPKI_PREFIX, publicKeyBytes.subarray(10)]),
+    format: 'der',
+    type: 'spki'
+  })
+  const dataDigest = crypto.createHash('blake2b512').update(data).digest()
+  const dataSignature = signatureBytes.subarray(10)
+  if (!crypto.verify(null, dataDigest, publicKey, dataSignature)) {
+    throw new Error('Invalid SHASUMS256.txt minisign signature')
+  }
+
+  const trustedComment = lines[2].replace(/^trusted comment: /, '')
+  const trustedCommentData = Buffer.concat([
+    dataSignature,
+    Buffer.from(trustedComment)
+  ])
+  if (
+    !crypto.verify(null, trustedCommentData, publicKey, trustedSignatureBytes)
+  ) {
+    throw new Error('Invalid minisign trusted comment signature')
+  }
+}
+
+function miseReleasePredatesMinisign(version: string): boolean {
+  const match = cleanVersion(version).match(/^(\d{4})\.(\d{1,2})\.(\d{1,2})/)
+  if (!match) {
+    return false
+  }
+  const [, year, month, patch] = match.map(Number)
+  if (year !== MISE_MINISIGN_STARTED_AT.year) {
+    return year < MISE_MINISIGN_STARTED_AT.year
+  }
+  if (month !== MISE_MINISIGN_STARTED_AT.month) {
+    return month < MISE_MINISIGN_STARTED_AT.month
+  }
+  return patch < MISE_MINISIGN_STARTED_AT.patch
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = crypto.createHash('sha256')
+  const fileBuffer = await fs.promises.readFile(filePath)
+  return hash.update(fileBuffer).digest('hex')
+}
+
+async function installFromTarFile(
+  archivePath: string,
+  tarArgs: string[],
+  tempDir: string,
+  miseBinPath: string
+): Promise<void> {
+  await exec.exec('tar', [...tarArgs, archivePath, '-C', tempDir])
+  const extractedMisePath = path.join(tempDir, 'mise', 'bin', 'mise')
   await exec.exec('mv', [extractedMisePath, miseBinPath])
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ const MISE_MINISIGN_PUBLIC_KEY =
   'RWTC3g8W3z4RZK3V3qv7fa1QY4JEWyBtqIHW+85QlJpZc5yG+uNYNBSZ'
 const MISE_MINISIGN_STARTED_AT = { year: 2024, month: 12, patch: 24 }
 const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex')
+const verifiedShasums = new Map<string, string>()
 
 type DownloadTool = 'curl' | 'wget'
 let cachedDownloadTool: DownloadTool | undefined
@@ -336,36 +337,27 @@ async function setupMise(
       process.platform === 'win32' ? '.exe' : ''
     }`
     const fetchFromCdn = !fetchFromGitHub && !version
-    const verifyAssetName = fetchFromCdn ? undefined : assetName
     const githubUrl = `https://github.com/jdx/mise/releases/download/v${resolvedVersion}/${assetName}`
-    let url: string
-    if (fetchFromCdn) {
-      // Only for latest version
-      url = `https://mise.jdx.dev/mise-latest-${target}${ext}`
-    } else {
-      url = githubUrl
-    }
+    const cdnUrl = `https://mise.jdx.dev/mise-latest-${target}${
+      process.platform === 'win32' ? '.exe' : ''
+    }`
     installedVersion = resolvedVersion
     const installFromUrl = async (
       downloadUrl: string,
-      checksumAssetName: string | undefined
+      downloadAssetName: string,
+      checksumAssetName: string,
+      extractArchive: boolean
     ): Promise<void> => {
-      let installedBinPath = miseBinPath
-      let installedShimPath = miseShimPath
       await withDownloadedMiseAsset(
         downloadUrl,
         resolvedVersion,
-        assetName,
+        downloadAssetName,
         checksumAssetName,
         async (downloadPath, tempDir) => {
-          if (!checksumAssetName) {
-            const candidateDir = path.join(tempDir, 'candidate', 'bin')
-            await fs.promises.mkdir(candidateDir, { recursive: true })
-            installedBinPath = path.join(
-              candidateDir,
-              process.platform === 'win32' ? 'mise.exe' : 'mise'
-            )
-            installedShimPath = path.join(candidateDir, 'mise-shim.exe')
+          if (!extractArchive) {
+            await io.mv(downloadPath, miseBinPath)
+            await exec.exec('chmod', ['+x', miseBinPath])
+            return
           }
           switch (ext) {
             case '.zip':
@@ -380,11 +372,11 @@ async function setupMise(
                   )
                   await io.mv(
                     path.join(extractedMiseBinDir, 'mise.exe'),
-                    installedBinPath
+                    miseBinPath
                   )
                   await installWindowsMiseShim(
                     extractedMiseBinDir,
-                    installedShimPath
+                    miseShimPath
                   )
                 }
               )
@@ -394,7 +386,7 @@ async function setupMise(
                 downloadPath,
                 ['--zstd', '-xf'],
                 tempDir,
-                installedBinPath
+                miseBinPath
               )
               break
             case '.tar.gz':
@@ -402,30 +394,23 @@ async function setupMise(
                 downloadPath,
                 ['-xzf'],
                 tempDir,
-                installedBinPath
+                miseBinPath
               )
               break
             default:
-              await io.mv(downloadPath, installedBinPath)
-              await exec.exec('chmod', ['+x', installedBinPath])
+              await io.mv(downloadPath, miseBinPath)
+              await exec.exec('chmod', ['+x', miseBinPath])
               break
-          }
-          if (!checksumAssetName) {
-            await verifyDownloadedMiseAsset(
-              installedBinPath,
-              resolvedVersion,
-              rawAssetName
-            )
-            await io.mv(installedBinPath, miseBinPath)
-            if (fs.existsSync(installedShimPath)) {
-              await io.mv(installedShimPath, miseShimPath)
-            }
           }
         }
       )
     }
     try {
-      await installFromUrl(url, verifyAssetName)
+      if (fetchFromCdn) {
+        await installFromUrl(cdnUrl, rawAssetName, rawAssetName, false)
+      } else {
+        await installFromUrl(githubUrl, assetName, assetName, true)
+      }
     } catch (err) {
       if (!fetchFromCdn) {
         throw err
@@ -433,7 +418,7 @@ async function setupMise(
       core.warning(
         `Could not verify mise from the CDN: ${errorMessage(err)}. Falling back to the verified GitHub release asset.`
       )
-      await installFromUrl(githubUrl, assetName)
+      await installFromUrl(githubUrl, assetName, assetName, true)
     }
   } else {
     const requestedVersion = cleanVersion(core.getInput('version'))
@@ -603,26 +588,42 @@ async function verifyDownloadedMiseAsset(
     return
   }
 
+  const shasums = await verifiedMiseShasums(version)
+  if (!shasums) {
+    return
+  }
+  const want = checksumForAsset(shasums, assetName)
+  const got = await sha256File(filePath)
+  if (got !== want) {
+    throw new Error(
+      `SHA256 mismatch: expected ${want}, got ${got} for ${assetName}`
+    )
+  }
+  core.info(`Verified ${assetName} against signed checksums`)
+}
+
+async function verifiedMiseShasums(
+  version: string
+): Promise<string | undefined> {
+  const cached = verifiedShasums.get(version)
+  if (cached) {
+    return cached
+  }
+
   try {
     const shasumsUrl = `https://github.com/jdx/mise/releases/download/v${version}/SHASUMS256.txt`
     const minisigUrl = `${shasumsUrl}.minisig`
     const shasums = await downloadRawText(shasumsUrl)
     const minisig = await downloadRawText(minisigUrl)
     verifyMinisign(shasums, minisig)
-    const want = checksumForAsset(shasums, assetName)
-    const got = await sha256File(filePath)
-    if (got !== want) {
-      throw new Error(
-        `SHA256 mismatch: expected ${want}, got ${got} for ${assetName}`
-      )
-    }
-    core.info(`Verified ${assetName} against signed checksums`)
+    verifiedShasums.set(version, shasums)
+    return shasums
   } catch (err) {
     if (miseReleasePredatesMinisign(version)) {
       core.warning(
         `Could not verify signed checksums for mise ${version}: ${errorMessage(err)}. Continuing because this pinned version predates mise minisign checksums.`
       )
-      return
+      return undefined
     }
     throw err
   }
@@ -647,7 +648,11 @@ function verifyMinisign(data: string, minisig: string): void {
   const publicKeyBytes = Buffer.from(MISE_MINISIGN_PUBLIC_KEY, 'base64')
   const signatureBytes = Buffer.from(lines[1], 'base64')
   const trustedSignatureBytes = Buffer.from(lines[3], 'base64')
-  if (publicKeyBytes.length !== 42 || signatureBytes.length !== 74) {
+  if (
+    publicKeyBytes.length !== 42 ||
+    signatureBytes.length !== 74 ||
+    trustedSignatureBytes.length !== 64
+  ) {
     throw new Error('Invalid minisign signature format')
   }
   if (!publicKeyBytes.subarray(2, 10).equals(signatureBytes.subarray(2, 10))) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -350,12 +350,23 @@ async function setupMise(
       downloadUrl: string,
       checksumAssetName: string | undefined
     ): Promise<void> => {
+      let installedBinPath = miseBinPath
+      let installedShimPath = miseShimPath
       await withDownloadedMiseAsset(
         downloadUrl,
         resolvedVersion,
         assetName,
         checksumAssetName,
         async (downloadPath, tempDir) => {
+          if (!checksumAssetName) {
+            const candidateDir = path.join(tempDir, 'candidate', 'bin')
+            await fs.promises.mkdir(candidateDir, { recursive: true })
+            installedBinPath = path.join(
+              candidateDir,
+              process.platform === 'win32' ? 'mise.exe' : 'mise'
+            )
+            installedShimPath = path.join(candidateDir, 'mise-shim.exe')
+          }
           switch (ext) {
             case '.zip':
               await withExtractedZip(
@@ -369,11 +380,11 @@ async function setupMise(
                   )
                   await io.mv(
                     path.join(extractedMiseBinDir, 'mise.exe'),
-                    miseBinPath
+                    installedBinPath
                   )
                   await installWindowsMiseShim(
                     extractedMiseBinDir,
-                    miseShimPath
+                    installedShimPath
                   )
                 }
               )
@@ -383,7 +394,7 @@ async function setupMise(
                 downloadPath,
                 ['--zstd', '-xf'],
                 tempDir,
-                miseBinPath
+                installedBinPath
               )
               break
             case '.tar.gz':
@@ -391,23 +402,27 @@ async function setupMise(
                 downloadPath,
                 ['-xzf'],
                 tempDir,
-                miseBinPath
+                installedBinPath
               )
               break
             default:
-              await io.mv(downloadPath, miseBinPath)
-              await exec.exec('chmod', ['+x', miseBinPath])
+              await io.mv(downloadPath, installedBinPath)
+              await exec.exec('chmod', ['+x', installedBinPath])
               break
+          }
+          if (!checksumAssetName) {
+            await verifyDownloadedMiseAsset(
+              installedBinPath,
+              resolvedVersion,
+              rawAssetName
+            )
+            await io.mv(installedBinPath, miseBinPath)
+            if (fs.existsSync(installedShimPath)) {
+              await io.mv(installedShimPath, miseShimPath)
+            }
           }
         }
       )
-      if (!checksumAssetName) {
-        await verifyDownloadedMiseAsset(
-          miseBinPath,
-          resolvedVersion,
-          rawAssetName
-        )
-      }
     }
     try {
       await installFromUrl(url, verifyAssetName)


### PR DESCRIPTION
## Summary
- embed mise's minisign public key and verify `SHASUMS256.txt.minisig` before trusting release checksums
- verify downloaded GitHub release archives before extraction, and verify CDN downloads against the signed checksum for the extracted mise binary
- fall back from the CDN to the verified GitHub release asset when the CDN bytes do not match the signed release checksum
- keep the existing `sha256` input as an explicit override, and warn instead of failing for pinned mise versions that predate minisign checksums

Closes #547

## Validation
- `mise x node -- npm run all`
- smoke-tested `dist/index.js` with `version=2026.7.1` and `fetch_from_github=true`
- smoke-tested `dist/index.js` with latest and `fetch_from_github=false`; this currently detects a stale CDN macOS arm64 asset, warns, falls back to GitHub, verifies the signed release asset, and installs `2026.7.2`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes supply-chain verification and download/install paths for the action’s own mise bootstrap; behavior shifts on CDN mismatch (fallback) and older pinned versions (warn-only).
> 
> **Overview**
> **Hardens mise binary installation** by verifying release artifacts against **minisign-signed** `SHASUMS256.txt` (embedded public key, Ed25519 verification) before extraction or install.
> 
> Downloads go through **`withDownloadedMiseAsset`**: fetch to a temp file, optional SHA256 check against signed sums, then install. **GitHub release archives** are verified before unzip/tar; **CDN “latest”** binaries are checked against the signed checksum for the matching release asset name. If CDN verification fails, the action **warns and falls back** to the verified GitHub asset.
> 
> The explicit **`sha256` input** still bypasses signed-checksum verification. **Pinned versions before 2024.12.24** get a warning and skip signed verification instead of failing. Tar installs no longer stream download→tar; they extract from a verified file on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d9be3c23b4c6e869c4240254816f0653e32378e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->