### PR TITLE
fix: exclude PATH from environment export

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
 
             [env]
             MY_ENV_VAR = "abc"
+            _.path = ["{{config_root}}/mise-env-path"]
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: mise --version

--- a/dist/index.js
+++ b/dist/index.js
@@ -89428,9 +89428,9 @@ async function exportMiseEnv() {
                 cwd
             });
             const actualVars = JSON.parse(actualOutput.stdout);
-            // Export all environment variables
+            // Export environment variables while leaving PATH management to the action
             for (const [key, value] of Object.entries(actualVars)) {
-                if (typeof value === 'string') {
+                if (typeof value === 'string' && key.toUpperCase() !== 'PATH') {
                     exportVariable(key, value);
                 }
             }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -19,3 +19,9 @@ fi
 
 # checking that environment variables set in mise.toml are properly set
 assert_equal "${MY_ENV_VAR}" "abc"
+
+# PATH modifications from mise.toml should not persist to subsequent steps
+if [[ "$PATH" == *"mise-env-path"* ]]; then
+	echo "mise env path unexpectedly exported to PATH: $PATH" >&2
+	exit 1
+fi

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,9 +186,9 @@ async function exportMiseEnv(): Promise<void> {
       })
       const actualVars = JSON.parse(actualOutput.stdout)
 
-      // Export all environment variables
+      // Export environment variables while leaving PATH management to the action
       for (const [key, value] of Object.entries(actualVars)) {
-        if (typeof value === 'string') {
+        if (typeof value === 'string' && key.toUpperCase() !== 'PATH') {
           core.exportVariable(key, value)
         }
       }


### PR DESCRIPTION
## Summary
- exclude `PATH` from variables exported by the `env` input
- preserve the documented behavior while continuing to export regular mise environment variables
- add matrix regression coverage for `[env] _.path`

## Root cause
The redaction support introduced in #252 switched environment loading from `mise env --dotenv` to `mise env --json`. Unlike dotenv output, JSON includes the computed `PATH`, and the action exported every returned string to `GITHUB_ENV`.

This keeps PATH management with the action's dedicated PATH setup and prevents a complete runner PATH snapshot from leaking into subsequent steps.

Closes #555

## Validation
- `mise run test` (format, lint, TypeScript bundle)
- pre-commit hook (`npm run all`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted guard on env export with regression tests; no auth or data-path changes.
> 
> **Overview**
> Fixes a regression where switching env export to `mise env --json` (for redaction) also wrote the full computed **PATH** into `GITHUB_ENV`, overriding how the action is supposed to manage PATH.
> 
> **`exportMiseEnv`** now skips any variable whose key is `PATH` (case-insensitive) when exporting JSON env vars, so only normal mise env vars (e.g. `MY_ENV_VAR`) are persisted to later steps. PATH continues to come from the action’s own setup (e.g. `add_shims_to_path`).
> 
> CI adds **`[env] _.path`** in the matrix `mise_toml` and **`scripts/test.sh`** asserts `PATH` does not contain `mise-env-path` after the setup step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e56f9ab400c1c594e831d30bdfad14004a27c71e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented environment setup from unintentionally modifying `PATH` during test runs.
  * Improved environment variable handling by excluding `PATH` from exported mise environment values.
  * Added validation to detect and report unexpected `PATH` changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->