### PR TITLE
chore(ci): automate weekly releases

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,74 @@
+name: auto-merge-release
+
+on:
+  schedule:
+    - cron: "0 10 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: auto-merge-release
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    if: github.repository == 'jdx/mise-action'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - name: Merge release into main
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" ]; then
+            latest_tag=$(git describe --tags --match 'v[0-9]*' --abbrev=0 || true)
+            if [ -n "$latest_tag" ]; then
+              range="${latest_tag}..HEAD"
+              tag_time=$(git for-each-ref --format='%(creatordate:unix)' "refs/tags/$latest_tag")
+              now=$(date +%s)
+              min_age=$((7 * 24 * 60 * 60))
+              age=$((now - tag_time))
+              if [ "$age" -lt "$min_age" ]; then
+                echo "Latest release ${latest_tag} is less than 7 days old; not auto-merging release PRs"
+                exit 0
+              fi
+            else
+              echo "No v[0-9]* release tag found; allowing bootstrap release"
+              range=""
+            fi
+            if [ -n "$range" ]; then
+              commit_subjects=$(git log --format=%s "$range")
+              if ! grep -Eq '^(fix|feat)(\([^)]+\))?!?: ' <<<"$commit_subjects"; then
+                echo "No pending fix/feat commits since the latest release; not auto-merging release PRs"
+                exit 0
+              fi
+            fi
+          else
+            echo "Manual dispatch; skipping release cadence guards"
+          fi
+
+          PR_NUMBER=$(gh pr list -R jdx/mise-action --base main --head release --state open --limit 100 --json number,headRefName,headRepositoryOwner \
+            --jq '[.[] | select(.headRefName == "release") | select(.headRepositoryOwner.login == "jdx")][0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR from release to main"
+            exit 0
+          fi
+
+          BODY=$(gh pr view "$PR_NUMBER" -R jdx/mise-action --json body --jq '.body // ""')
+          TRIMMED_BODY=$(echo "$BODY" | tr -d '[:space:]')
+          if [ -z "$TRIMMED_BODY" ]; then
+            echo "Skipping merge: PR #$PR_NUMBER has an empty body; will retry on the next scheduled run"
+            exit 0
+          fi
+
+          echo "PR #$PR_NUMBER is ready for the daily release window"
+          gh pr merge "$PR_NUMBER" -R jdx/mise-action --squash --auto
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- add a scheduled workflow that checks for an eligible release PR each day
- enforce a seven-day minimum between automatic releases
- require pending `fix` or `feat` commits before enabling auto-merge
- support manual dispatch that bypasses the cadence guards

## Impact

`mise-action` release PRs will publish automatically on the same weekly cadence as the other jdx projects, while still allowing manual releases when needed.

## Validation

- `mise exec -- aubr all`
- `mise x actionlint -- actionlint .github/workflows/auto-merge-release.yml`
- `mise x zizmor -- zizmor .github/workflows/auto-merge-release.yml`
- `npx prettier --check .github/workflows/auto-merge-release.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uses a privileged token to enable auto-merge on release PRs; guards limit blast radius but mistaken criteria could still merge releases earlier than intended.
> 
> **Overview**
> Adds a new **`auto-merge-release`** GitHub Actions workflow that runs daily (10:00 UTC) and on manual dispatch to auto-merge an open **`release` → `main`** PR when release criteria are met.
> 
> On scheduled runs it **skips** merging if the latest `v*` tag is newer than seven days, if there are no `fix`/`feat` conventional commits since that tag, if no eligible PR exists, or if the PR body is empty. **Manual dispatch** bypasses the tag age and commit-subject guards. When checks pass, it runs **`gh pr merge --squash --auto`** using **`RELEASE_PLZ_GITHUB_TOKEN`**, aligning automated publishing with the existing release-plz setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bcaedaff0251138818b6d157190e444be1d5a17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated release workflow that checks for eligible release pull requests and enables squash auto-merge.
  * Scheduled runs enforce a minimum seven-day interval between releases and require recent feature or bug-fix changes.
  * Release automation can also be triggered manually when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->