### PR TITLE
fix(release-plz): exit when git-cliff produces no version bump

### DIFF
--- a/scripts/release-plz.sh
+++ b/scripts/release-plz.sh
@@ -27,8 +27,18 @@ if [ -n "$latest_release_version" ] && [ "$cur_pkg_version" = "$latest_release_v
 		echo "Found $commits_since_release commits since $latest_tag"
 	fi
 
-	# Get the next version and changelog from git-cliff
+	# Get the next version from git-cliff
 	version="$(git cliff --bumped-version)"
+
+	# If git-cliff couldn't bump the version (e.g. only chore/deps commits
+	# since the last release), there's nothing to release. Bailing here avoids
+	# a later `npm version <same>` failure ("Version not changed").
+	if [ "$version" = "$latest_tag" ] || [ "${version#v}" = "$cur_pkg_version" ]; then
+		echo "No version bump from commits since $latest_tag; nothing to release."
+		exit 0
+	fi
+
+	# Get the changelog from git-cliff
 	changelog="$(git cliff --bump --unreleased | tail -n +2)"
 
 	if [ "${DRY_RUN:-1}" == 1 ]; then


### PR DESCRIPTION
## Problem

The [release-plz workflow](https://github.com/jdx/mise-action/actions/runs/29794049055/job/88521647762) fails at `npm version 4.2.1 --no-git-tag-version` with `npm error Version not changed` (exit 1).

The chain of events in `scripts/release-plz.sh`:

1. `package.json` (4.2.1) matches the latest release (v4.2.1) → takes the "Nothing to release" branch, then checks for unreleased changes.
2. There are 6 commits since v4.2.1, but they're all `chore(deps)` Renovate commits.
3. `git cliff --bumped-version` returns **v4.2.1** (`WARN > There is nothing to bump`) because those commits don't trigger a semver bump.
4. The existing changelog guard doesn't catch this — `git cliff --bump --unreleased` still emits a non-empty block that isn't *exactly* `<!-- generated by git-cliff -->`.
5. The script proceeds to `npm version 4.2.1` (same version) → npm errors out.

## Fix

Bail out early when the git-cliff bumped version equals the latest tag / current package version, so the job succeeds with nothing to do instead of attempting a no-op version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation script only; no runtime product or security behavior changes.
> 
> **Overview**
> Fixes **release-plz** CI failures when there are commits since the last tag but **git-cliff** does not semver-bump (e.g. only `chore(deps)` commits).
> 
> `scripts/release-plz.sh` now exits successfully right after `git cliff --bumped-version` if that version still matches the latest tag or `package.json`, instead of continuing to `npm version` with the same version and hitting **Version not changed**. Changelog generation is moved to run only after this check passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53b51fde0503c4fabff48975456664ae798083ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->