### PR TITLE
chore: release v4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 ---
+## [4.2.2](https://github.com/jdx/mise-action/compare/v4.2.1..v4.2.2) - 2026-07-24
+
+### 🐛 Bug Fixes
+
+- **(release-plz)** exit when git-cliff produces no version bump (#566) by [@jdx](https://github.com/jdx) in [#566](https://github.com/jdx/mise-action/pull/566)
+- ensure `tar` supports Zstd (#569) by [@JackMyers001](https://github.com/JackMyers001) in [#569](https://github.com/jdx/mise-action/pull/569)
+
+### 📚 Documentation
+
+- update default value of `cache_key_prefix` (#570) by [@muzimuzhi](https://github.com/muzimuzhi) in [#570](https://github.com/jdx/mise-action/pull/570)
+
+### New Contributors
+
+* @muzimuzhi made their first contribution in [#570](https://github.com/jdx/mise-action/pull/570)
+* @JackMyers001 made their first contribution in [#569](https://github.com/jdx/mise-action/pull/569)
+
+---
 ## [4.2.1](https://github.com/jdx/mise-action/compare/v4.2.0..v4.2.1) - 2026-07-16
 
 ### 🐛 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mise-action",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mise-action",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "author": "jdx",
   "type": "module",
   "private": true,


### PR DESCRIPTION

---
## [4.2.2](https://github.com/jdx/mise-action/compare/v4.2.1..v4.2.2) - 2026-07-24

### 🐛 Bug Fixes

- **(release-plz)** exit when git-cliff produces no version bump (#566) by [@jdx](https://github.com/jdx) in [#566](https://github.com/jdx/mise-action/pull/566)
- ensure `tar` supports Zstd (#569) by [@JackMyers001](https://github.com/JackMyers001) in [#569](https://github.com/jdx/mise-action/pull/569)

### 📚 Documentation

- update default value of `cache_key_prefix` (#570) by [@muzimuzhi](https://github.com/muzimuzhi) in [#570](https://github.com/jdx/mise-action/pull/570)

### New Contributors

* @muzimuzhi made their first contribution in [#570](https://github.com/jdx/mise-action/pull/570)
* @JackMyers001 made their first contribution in [#569](https://github.com/jdx/mise-action/pull/569)

<!-- generated by git-cliff -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release PR with no application logic changes in the diff.
> 
> **Overview**
> **Release v4.2.2** — bumps the package version from `4.2.1` to `4.2.2` in `package.json` and `package-lock.json`, and prepends a **4.2.2** section to `CHANGELOG.md` (git-cliff).
> 
> That release documents fixes merged since 4.2.1: **release-plz** exits when git-cliff reports no version bump (#566), **tar** is validated for Zstd support before use (#569), and docs correct the default for `cache_key_prefix` (#570). This PR does not change action runtime code beyond the version metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c0c95bf375ff1b5b25c6a6f087829d40010d841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->