### PR TITLE
fix: ensure `tar` supports Zstd

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -89542,7 +89542,7 @@ async function setupMise(version, fetchFromGitHub = false) {
             ? '.zip'
             : version && version.startsWith('2024')
                 ? ''
-                : (await zstdInstalled())
+                : (await tarSupportsZstd())
                     ? '.tar.zst'
                     : '.tar.gz';
         let resolvedVersion = version || (await latestMiseVersion());
@@ -89828,9 +89828,10 @@ async function getInstalledMiseVersion(miseBinPath) {
 function errorMessage(err) {
     return err instanceof Error ? err.message : String(err);
 }
-async function zstdInstalled() {
+async function tarSupportsZstd() {
     try {
         await exec('zstd', ['--version']);
+        await exec('tar', ['--zstd', '--version']);
         return true;
     }
     catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -326,7 +326,7 @@ async function setupMise(
         ? '.zip'
         : version && version.startsWith('2024')
           ? ''
-          : (await zstdInstalled())
+          : (await tarSupportsZstd())
             ? '.tar.zst'
             : '.tar.gz'
     let resolvedVersion = version || (await latestMiseVersion())
@@ -728,9 +728,10 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
-async function zstdInstalled(): Promise<boolean> {
+async function tarSupportsZstd(): Promise<boolean> {
   try {
     await exec.exec('zstd', ['--version'])
+    await exec.exec('tar', ['--zstd', '--version'])
     return true
   } catch {
     return false


### PR DESCRIPTION
## Summary

- Updates decision for downloading Zstd archive to check that the version of `tar` installed supports Zstd

## Root Cause

As noted in #568, the action previously selected a Zstd-compressed archive after checking only `zstd --version`, but extracts the archive with `tar --zstd`. This fails on RHEL 8-compatible runners that ship `zstd` 1.4.4 and GNU `tar` 1.30, which does not recognize the `--zstd` option.

Fixes #568.

## Validation

- Underlying problem (missing `--zstd` flag confirmed within a RHEL 8 VM + `almalinux:8` container
  - Confirmed `zstd --version` exits successfully
  - Confirmed `tar --zstd --version` exits with an unrecognized-option error in this environment, but works with newer `tar` versions (checked with `1.35`, but should be available from ~1.31)
- Run on a real RHEL8 self-hosted Runner that fails without this patch

I was unable to run `mise run test` or the pre-commit hook due to `npm install` failing; all passed after downgrading TypeScript to v6 (this appears to be unrelated to my change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive selection to verify full `.tar.zst` support before use.
  * Automatically falls back to `.tar.gz` archives when the system’s `tar` command cannot handle Zstandard compression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->