### PR TITLE
docs: update default value of `cache_key_prefix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can customize the cache key used by the action:
 - uses: jdx/mise-action@v4
   with:
     cache_key: "my-custom-cache-key"  # Override the entire cache key
-    cache_key_prefix: "mise-v1"       # Or just change the prefix (default: "mise-v0")
+    cache_key_prefix: "mise-cache-v1"       # Or just change the prefix (default: "mise-v1")
 ```
 
 ### Template Variables in Cache Keys


### PR DESCRIPTION
Default `cache_key_prefix` was bumped from `mise-v0` to `mise-v1` in f1c6089fba7d09fbba0926ecdb657bb576d3e57a.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the cache configuration example to use the `mise-cache-v1` key prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->