### PR TITLE
chore: release v4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ---
+## [4.2.3](https://github.com/jdx/mise-action/compare/v4.2.2..v4.2.3) - 2026-07-24
+
+### 🐛 Bug Fixes
+
+- export mise path entries to subsequent steps (#575) by [@jdx](https://github.com/jdx) in [#575](https://github.com/jdx/mise-action/pull/575)
+
+---
 ## [4.2.2](https://github.com/jdx/mise-action/compare/v4.2.1..v4.2.2) - 2026-07-24
 
 ### 🐛 Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "author": "jdx",
   "type": "module",
   "private": true,


### PR DESCRIPTION

---
## [4.2.3](https://github.com/jdx/mise-action/compare/v4.2.2..v4.2.3) - 2026-07-24

### 🐛 Bug Fixes

- export mise path entries to subsequent steps (#575) by [@jdx](https://github.com/jdx) in [#575](https://github.com/jdx/mise-action/pull/575)

<!-- generated by git-cliff -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only in this PR; the underlying fix is PATH export behavior for CI workflows, not auth or data handling.
> 
> **Overview**
> **Release v4.2.3** bumps `package.json` from **4.2.2** to **4.2.3** and adds a **4.2.3** section to `CHANGELOG.md`.
> 
> The release ships the bug fix from [#575](https://github.com/jdx/mise-action/pull/575): **mise `_.path` / PATH entries are exported to later workflow steps** (via `GITHUB_PATH`) instead of being dropped or only affecting the action step. Use `export_path: false` if you still want env vars without persisting mise PATH changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 163461a5bb7f226802d77bceaf7362b5f583ad0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->