### PR TITLE
chore: release v4.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ---
+## [4.2.4](https://github.com/jdx/mise-action/compare/v4.2.3..v4.2.4) - 2026-07-28
+
+### 🐛 Bug Fixes
+
+- locking support detection with force-colored output (#580) by [@scop](https://github.com/scop) in [#580](https://github.com/jdx/mise-action/pull/580)
+
+---
 ## [4.2.3](https://github.com/jdx/mise-action/compare/v4.2.2..v4.2.3) - 2026-07-24
 
 ### 🐛 Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "author": "jdx",
   "type": "module",
   "private": true,


### PR DESCRIPTION

---
## [4.2.4](https://github.com/jdx/mise-action/compare/v4.2.3..v4.2.4) - 2026-07-28

### 🐛 Bug Fixes

- locking support detection with force-colored output (#580) by [@scop](https://github.com/scop) in [#580](https://github.com/jdx/mise-action/pull/580)

<!-- generated by git-cliff -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only (version + changelog); no runtime code changes in this diff.
> 
> **Overview**
> **Release v4.2.4** bumps the package version from `4.2.3` to `4.2.4` and adds a **4.2.4** section to `CHANGELOG.md`.
> 
> That release documents one bug fix shipped in [#580](https://github.com/jdx/mise-action/pull/580): **locking support detection** when mise output uses **force-colored** text (so `mise install --locked` auto-detection still works in CI where color is forced).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b72563fa6554206ae4b408c9d5e4ceb43fe90b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->