### PR TITLE
chore: release v4.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
 ---
-## [4.2.4](https://github.com/jdx/mise-action/compare/v4.2.3..v4.2.4) - 2026-07-28
+## [4.2.5](https://github.com/jdx/mise-action/compare/v4.2.4..v4.2.5) - 2026-08-12
+
+### 🐛 Bug Fixes
+
+- retry mise downloads after transient failures (#597) by [@jdx](https://github.com/jdx) in [#597](https://github.com/jdx/mise-action/pull/597)
+
+---
+## [4.2.4](https://github.com/jdx/mise-action/compare/v4.2.3..v4.2.4) - 2026-08-01
 
 ### 🐛 Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "author": "jdx",
   "type": "module",
   "private": true,


### PR DESCRIPTION

---
## [4.2.5](https://github.com/jdx/mise-action/compare/v4.2.4..v4.2.5) - 2026-08-12

### 🐛 Bug Fixes

- retry mise downloads after transient failures (#597) by [@jdx](https://github.com/jdx) in [#597](https://github.com/jdx/mise-action/pull/597)

<!-- generated by git-cliff -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only in this PR; the underlying fix is a resilience improvement for downloads.
> 
> **Overview**
> **Release v4.2.5** bumps the published package version and documents the changes since v4.2.4.
> 
> The changelog entry for this release highlights **retrying mise binary downloads after transient failures** (#597), which is the functional change consumers get when they move from `4.2.4` to `4.2.5`. The diff in this PR itself only updates `package.json` to `4.2.5` and adds the corresponding **4.2.5** section to `CHANGELOG.md` (including a corrected release date for the 4.2.4 entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bc5e3b17fa675eca96a0ee8779cb9556d79628b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->