### PR TITLE
chore: release v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
 ---
-## [4.2.5](https://github.com/jdx/mise-action/compare/v4.2.4..v4.2.5) - 2026-08-12
+## [4.3.0](https://github.com/jdx/mise-action/compare/v4.2.5..v4.3.0) - 2026-08-24
+
+### 🚀 Features
+
+- add minimum release age for mise (#604) by [@jdx](https://github.com/jdx) in [#604](https://github.com/jdx/mise-action/pull/604)
+
+---
+## [4.2.5](https://github.com/jdx/mise-action/compare/v4.2.4..v4.2.5) - 2026-08-13
 
 ### 🐛 Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mise-action",
   "description": "mise tool setup action",
-  "version": "4.2.5",
+  "version": "4.3.0",
   "author": "jdx",
   "type": "module",
   "private": true,


### PR DESCRIPTION

---
## [4.3.0](https://github.com/jdx/mise-action/compare/v4.2.5..v4.3.0) - 2026-08-24

### 🚀 Features

- add minimum release age for mise (#604) by [@jdx](https://github.com/jdx) in [#604](https://github.com/jdx/mise-action/pull/604)

<!-- generated by git-cliff -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release metadata; no runtime or security logic changes.
> 
> **Overview**
> Cuts **v4.3.0** by bumping `package.json` from `4.2.5` and adding a changelog entry for the minimum release age feature (#604). Also corrects the 4.2.5 changelog date to 2026-08-13.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84e4f59d29c63ad4cc6c10c9d307e8061ffc9fea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->